### PR TITLE
Removing unnecessary code

### DIFF
--- a/src/main/java/org/javamoney/moneta/convert/internal/ECBCurrentRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/convert/internal/ECBCurrentRateProvider.java
@@ -221,7 +221,7 @@ public class ECBCurrentRateProvider extends AbstractRateProvider implements Load
                 if("Cube".equals(qName)){
                     if(attributes.getValue("time") != null){
                         Date date = dateFormat.parse(attributes.getValue("time"));
-                        timestamp = Long.valueOf(date.getTime());
+                        timestamp = date.getTime();
                     }else if(attributes.getValue("currency") != null){
                         // read data <Cube currency="USD" rate="1.3349"/>
                         CurrencyUnit tgtCurrency = MonetaryCurrencies.getCurrency(attributes.getValue("currency"));

--- a/src/main/java/org/javamoney/moneta/convert/internal/ECBHistoric90RateProvider.java
+++ b/src/main/java/org/javamoney/moneta/convert/internal/ECBHistoric90RateProvider.java
@@ -138,7 +138,7 @@ public class ECBHistoric90RateProvider extends AbstractRateProvider implements L
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
-        Long targetTS = Long.valueOf(cal.getTimeInMillis());
+        Long targetTS = cal.getTimeInMillis();
 
         builder.setBase(base);
         builder.setTerm(term);
@@ -224,7 +224,7 @@ public class ECBHistoric90RateProvider extends AbstractRateProvider implements L
                 if("Cube".equals(qName)){
                     if(attributes.getValue("time") != null){
                         Date date = dateFormat.parse(attributes.getValue("time"));
-                        timestamp = Long.valueOf(date.getTime());
+                        timestamp = date.getTime();
                     }else if(attributes.getValue("currency") != null){
                         // read data <Cube currency="USD" rate="1.3349"/>
                         CurrencyUnit tgtCurrency = MonetaryCurrencies.getCurrency(attributes.getValue("currency"));

--- a/src/main/java/org/javamoney/moneta/convert/internal/ECBHistoricRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/convert/internal/ECBHistoricRateProvider.java
@@ -142,7 +142,7 @@ public class ECBHistoricRateProvider extends AbstractRateProvider implements Loa
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
-        Long targetTS = Long.valueOf(cal.getTimeInMillis());
+        Long targetTS = cal.getTimeInMillis();
         Map<String,ExchangeRate> targets = this.historicRates.get(targetTS);
         if(targets == null){
             return null;
@@ -233,7 +233,7 @@ public class ECBHistoricRateProvider extends AbstractRateProvider implements Loa
                 if("Cube".equals(qName)){
                     if(attributes.getValue("time") != null){
                         Date date = dateFormat.parse(attributes.getValue("time"));
-                        timestamp = Long.valueOf(date.getTime());
+                        timestamp = date.getTime();
                     }else if(attributes.getValue("currency") != null){
                         // read data <Cube currency="USD" rate="1.3349"/>
                         CurrencyUnit tgtCurrency = MonetaryCurrencies.getCurrency(attributes.getValue("currency"));
@@ -261,7 +261,7 @@ public class ECBHistoricRateProvider extends AbstractRateProvider implements Loa
         RateType rateType = RateType.HISTORIC;
         ExchangeRate.Builder builder = null;
         if(timestamp != null){
-            if(timestamp.longValue() > System.currentTimeMillis()){
+            if(timestamp > System.currentTimeMillis()){
                 rateType = RateType.DEFERRED;
             }
             builder = new ExchangeRate.Builder(new ConversionContext.Builder(CONTEXT, rateType).setAttribute(TIMESTAMP, timestamp).build());

--- a/src/main/java/org/javamoney/moneta/convert/internal/IMFRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/convert/internal/IMFRateProvider.java
@@ -270,10 +270,10 @@ public class IMFRateProvider extends AbstractRateProvider implements LoaderListe
     private boolean isValid(ConversionContext conversionContext, Long timestamp){
         Long validFrom = conversionContext.getNamedAttribute("validFrom", Long.class);
         Long validTo = conversionContext.getNamedAttribute("validTo", Long.class);
-        if(validFrom!=null && validFrom.longValue() > timestamp.longValue()){
+        if(validFrom!=null && validFrom > timestamp){
             return false;
         }
-        if(validTo!=null && validTo.longValue() < timestamp.longValue()){
+        if(validTo!=null && validTo < timestamp){
             return false;
         }
         return true;

--- a/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -802,8 +802,8 @@ public class FastMoneyTest{
         FastMoney[] moneys = new FastMoney[]{FastMoney.of(100, "CHF"), FastMoney.of(34242344, "USD"),
                 FastMoney.of(23123213.435, "EUR"), FastMoney.of(-23123213.435, "USS"), FastMoney.of(-23123213, "USN"),
                 FastMoney.of(0, "GBP")};
-        for(int i = 0; i < moneys.length; i++){
-            assertEquals((Integer) moneys[i].query(q), (Integer) moneys[i].getPrecision());
+        for (FastMoney money : moneys) {
+            assertEquals((Integer) money.query(q), (Integer) money.getPrecision());
         }
     }
 

--- a/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -957,8 +957,8 @@ public class MoneyTest{
         };
         Money[] moneys = new Money[]{Money.of(100, "CHF"), Money.of(34242344, "USD"), Money.of(23123213.435, "EUR"),
                 Money.of(-23123213.435, "USS"), Money.of(-23123213, "USN"), Money.of(0, "GBP")};
-        for(int i = 0; i < moneys.length; i++){
-            assertEquals((Integer) moneys[i].query(q), Integer.valueOf(moneys[i].getNumber().getPrecision()));
+        for (Money money : moneys) {
+            assertEquals((Integer) money.query(q), Integer.valueOf(money.getNumber().getPrecision()));
         }
     }
 

--- a/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
+++ b/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
@@ -1064,10 +1064,10 @@ public class RoundedMoneyTest {
 				RoundedMoney.of( 23123213.435,"EUR"),
 				RoundedMoney.of( -23123213.435,"USS"),
 				RoundedMoney.of( -23123213,"USN"), RoundedMoney.of( 0,"GBP") };
-		for (int i = 0; i < moneys.length; i++) {
-			assertEquals((Integer) moneys[i].query(q),
-					(Integer) moneys[i].getPrecision());
-		}
+        for (RoundedMoney money : moneys) {
+            assertEquals((Integer) money.query(q),
+                    (Integer) money.getPrecision());
+        }
 	}
 
 	/**

--- a/src/test/java/org/javamoney/moneta/function/MonetaryRoundingsTest.java
+++ b/src/test/java/org/javamoney/moneta/function/MonetaryRoundingsTest.java
@@ -71,19 +71,19 @@ public class MonetaryRoundingsTest{
                 MonetaryAmounts.getAmountFactory().setCurrency("CHF").setNumber(new BigDecimal("-1.500000000000"))
                         .create()};
         int[] scales = new int[]{0, 1, 2, 3, 4, 5};
-        for(int i = 0; i < samples.length; i++){
-            for(int scale : scales){
-                for(RoundingMode roundingMode : RoundingMode.values()){
-                    if(roundingMode == RoundingMode.UNNECESSARY){
+        for (MonetaryAmount sample : samples) {
+            for (int scale : scales) {
+                for (RoundingMode roundingMode : RoundingMode.values()) {
+                    if (roundingMode == RoundingMode.UNNECESSARY) {
                         continue;
                     }
                     MonetaryOperator rounding = MonetaryRoundings.getRounding(
                             new RoundingContext.Builder().setInt("scale", scale).setObject(roundingMode)
                                     .build()
                     );
-                    BigDecimal dec = samples[i].getNumber().numberValue(BigDecimal.class);
+                    BigDecimal dec = sample.getNumber().numberValue(BigDecimal.class);
                     BigDecimal expected = dec.setScale(scale, roundingMode);
-                    MonetaryAmount r = samples[i].with(rounding);
+                    MonetaryAmount r = sample.with(rounding);
                     assertEquals(MonetaryAmounts.getAmountFactory().setCurrency("CHF").setNumber(expected).create(), r);
                 }
             }
@@ -112,26 +112,26 @@ public class MonetaryRoundingsTest{
                         .create(),
                 MonetaryAmounts.getAmountFactory().setCurrency("CHF").setNumber(new BigDecimal("-1.500000000000"))
                         .create()};
-        for(int i = 0; i < samples.length; i++){
-            for(Currency currency : Currency.getAvailableCurrencies()){
+        for (MonetaryAmount sample : samples) {
+            for (Currency currency : Currency.getAvailableCurrencies()) {
                 CurrencyUnit cur = MonetaryCurrencies.getCurrency(currency.getCurrencyCode());
                 // Omit test roundings, which are for testing only...
-                if("XXX".equals(cur.getCurrencyCode())){
+                if ("XXX".equals(cur.getCurrencyCode())) {
                     continue;
-                }else if("CHF".equals(cur.getCurrencyCode())){
+                } else if ("CHF".equals(cur.getCurrencyCode())) {
                     continue;
                 }
                 MonetaryOperator rounding = MonetaryRoundings.getRounding(cur);
-                BigDecimal dec = samples[i].getNumber().numberValue(BigDecimal.class);
+                BigDecimal dec = sample.getNumber().numberValue(BigDecimal.class);
                 BigDecimal expected = null;
-                if(cur.getDefaultFractionDigits() < 0){
+                if (cur.getDefaultFractionDigits() < 0) {
                     expected = dec.setScale(0, RoundingMode.HALF_UP);
-                }else{
+                } else {
                     expected = dec.setScale(cur.getDefaultFractionDigits(), RoundingMode.HALF_UP);
                 }
-                MonetaryAmount r = samples[i].with(rounding);
-                assertEquals("Rouding for: " + samples[i],
-                             MonetaryAmounts.getAmountFactory().setCurrency("CHF").setNumber(expected).create(), r);
+                MonetaryAmount r = sample.with(rounding);
+                assertEquals("Rouding for: " + sample,
+                        MonetaryAmounts.getAmountFactory().setCurrency("CHF").setNumber(expected).create(), r);
             }
         }
     }


### PR DESCRIPTION
With Java 5 use boxing and unboxing are unnecessary because it is made automatically by JVM, it doesn't impact on performance, but get the code more clean.
Use of foreach is cleaner than use for with index, also just clean code.
