### PR TITLE
best way with performance to create array

### DIFF
--- a/src/main/java/org/javamoney/moneta/loader/internal/LoaderConfigurator.java
+++ b/src/main/java/org/javamoney/moneta/loader/internal/LoaderConfigurator.java
@@ -100,7 +100,7 @@ class LoaderConfigurator {
 			}
 			urls.add(new URL(res.trim()));
 		}
-		return urls.toArray(new URL[0]);
+		return urls.toArray(new URL[urls.size()]);
 	}
 
 	private URL getClassLoaderLocation(String res) {


### PR DESCRIPTION
When passing in an array of too small size, the toArray() method has to construct a new array of the right size using reflection. This has significantly worse performance than passing in an array of at least the size of the collection itself. 
