### PR TITLE
fix compare to problem

### DIFF
--- a/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
+++ b/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
@@ -78,6 +78,7 @@ public final class BuildableCurrencyUnit implements CurrencyUnit, Comparable<Cur
 
     @Override
     public int compareTo(CurrencyUnit o){
+    	Objects.requireNonNull(o);
         return this.currencyCode.compareTo(o.getCurrencyCode());
     }
 

--- a/src/main/java/org/javamoney/moneta/DefaultExchangeRate.java
+++ b/src/main/java/org/javamoney/moneta/DefaultExchangeRate.java
@@ -219,9 +219,7 @@ public class DefaultExchangeRate implements ExchangeRate, Serializable, Comparab
      */
     @Override
     public int compareTo(ExchangeRate o){
-        if (Objects.isNull(o)) {
-            return -1;
-        }
+        Objects.requireNonNull(o);
         int compare = this.getBase().getCurrencyCode().compareTo(o.getBase().getCurrencyCode());
         if(compare == 0){
             compare = this.getTerm().getCurrencyCode().compareTo(o.getTerm().getCurrencyCode());

--- a/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -207,6 +207,7 @@ public final class FastMoney extends AbstractMoney implements Comparable<Monetar
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     public int compareTo(MonetaryAmount o){
+    	Objects.requireNonNull(o);
         int compare = getCurrency().getCurrencyCode().compareTo(o.getCurrency().getCurrencyCode());
         if(compare == 0){
             compare = getNumber().numberValue(BigDecimal.class).compareTo(o.getNumber().numberValue(BigDecimal.class));

--- a/src/main/java/org/javamoney/moneta/internal/JDKCurrencyAdapter.java
+++ b/src/main/java/org/javamoney/moneta/internal/JDKCurrencyAdapter.java
@@ -117,6 +117,7 @@ final class JDKCurrencyAdapter implements CurrencyUnit, Serializable,
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 */
 	public int compareTo(CurrencyUnit currency) {
+		Objects.requireNonNull(currency);
 		return getCurrencyCode().compareTo(currency.getCurrencyCode());
 	}
 

--- a/src/test/java/org/javamoney/moneta/TestCurrency.java
+++ b/src/test/java/org/javamoney/moneta/TestCurrency.java
@@ -123,6 +123,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable,
 	}
 
 	public int compareTo(CurrencyUnit currency) {
+		Objects.requireNonNull(currency);
 		return getCurrencyCode().compareTo(currency.getCurrencyCode());
 	}
 
@@ -248,6 +249,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable,
 		// }
 
 		public int compareTo(CurrencyUnit currency) {
+			Objects.requireNonNull(currency);
 			int compare = getCurrencyCode().compareTo(
 					currency.getCurrencyCode());
 			if (compare == 0) {


### PR DESCRIPTION
By documentations compareTo should returns NPE when the object is null.
Using Objects.requireNonNull it avoid the JIT blind the class and then make it slower.
https://bugs.openjdk.java.net/browse/JDK-8042127
