### PR TITLE
BuildableCurrencyUnit should be Serializable

### DIFF
--- a/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
+++ b/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
@@ -16,8 +16,8 @@
 package org.javamoney.moneta;
 
 import javax.money.*;
-import javax.money.CurrencyContext;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -26,9 +26,13 @@ import java.util.Objects;
  * singleton, which publishes the instances, so they are visible from the {@link javax.money.MonetaryCurrencies}
  * singleton.
  */
-final class BuildableCurrencyUnit implements CurrencyUnit, Comparable<CurrencyUnit>{
+final class BuildableCurrencyUnit implements CurrencyUnit, Comparable<CurrencyUnit>, Serializable {
 
     /**
+     * serialVersionUID.
+     */
+	private static final long serialVersionUID = -2389580389919492220L;
+	/**
      * The unique currency code.
      */
     private String currencyCode;

--- a/src/test/java/org/javamoney/moneta/BuildableCurrencyUnitTest.java
+++ b/src/test/java/org/javamoney/moneta/BuildableCurrencyUnitTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2012, 2014, Credit Suisse (Anatole Tresch), Werner Keil and others by the @author tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.javamoney.moneta;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import javax.money.CurrencyUnit;
+
+import org.testng.annotations.Test;
+
+/**
+ * 
+ * @author Philippe Marschall
+ */
+public class BuildableCurrencyUnitTest {
+	
+	/**
+	 * Tests that currencies built by {@link CurrencyUnitBuilder} are serializable.
+	 */
+	@Test
+	public void testSerialization() throws ClassNotFoundException, IOException {
+		CurrencyUnit currencyUnit = CurrencyUnitBuilder.of("SDR", "serialization-test")
+				.setDefaultFractionDigits(3).build(false);
+		
+		CurrencyUnit copy = (CurrencyUnit) deserailize(serailize(currencyUnit));
+		assertEquals(currencyUnit, copy);
+	}
+	
+	private byte[] serailize(Object obj) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		try (ObjectOutputStream objectStream = new ObjectOutputStream(out)) {
+			objectStream.writeObject(obj);
+		}
+		return out.toByteArray();
+	}
+	
+	private Object deserailize(byte[] buf) throws IOException, ClassNotFoundException {
+		try (InputStream in = new ByteArrayInputStream(buf);
+			ObjectInputStream objectStream = new ObjectInputStream(in)) {
+			return objectStream.readObject();
+		}
+	}
+
+}


### PR DESCRIPTION
I believe that `BuildableCurrencyUnit` is intended to be `Serializable`
because `Money` is `Serializable` and has a field named currency which
is a `CurrencyUnit`. So in order for `Money` to be `Serializable` all
fields have to be `Serializable` as well. The other option would be to
mark `CurrencyUnit` as `Serializable`.
- make `BuildableCurrencyUnit` `Serializable`
- add test that ensures `BuildableCurrencyUnit` is `Serializable`
