### PR TITLE
Tests for FastMoney overflows

### DIFF
--- a/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -787,7 +787,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         if (multiplicand == 0) {
             return new FastMoney(0L, this.currency);
         }
-        return new FastMoney(multiplicand * this.number, this.currency);
+        return new FastMoney(Math.multiplyExact(multiplicand, this.number), this.currency);
     }
 
     @Override


### PR DESCRIPTION
Tests for various edge cases in FastMoney:
- `FastMoney#multiply(Number)` looks broken in
  #cc64343967f8aa38002513f1e99f6ff905660f72
- `FastMoney#divide(Number)` throws a `ArithmeticException` even if the
  result would fit into FastMoney
- `FastMoney#multiply(Number)` used `#doubleValue()` which lost precision
  fixed by #cc64343967f8aa38002513f1e99f6ff905660f72
- tests for cases that would have silently overflown before
  #cc64343967f8aa38002513f1e99f6ff905660f72
- `FastMoneymultiply(long)` did not use the exact method from `Math`
  and was silently overflowing

This commit contains two failing tests points 1 and 2 above.
