### PR TITLE
Tests for Special Doubles

### DIFF
--- a/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -20,8 +20,11 @@ import org.testng.annotations.Test;
 import javax.money.*;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.testng.Assert.*;
 
@@ -29,6 +32,8 @@ import static org.testng.Assert.*;
  * @author Anatole
  */
 public class FastMoneyTest{
+    
+    private static final Logger LOG = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
 
     private static final BigDecimal TEN = new BigDecimal(10.0d);
     protected static final CurrencyUnit EURO = MonetaryCurrencies.getCurrency("EUR");
@@ -407,6 +412,123 @@ public class FastMoneyTest{
     public void testMultiplyDouble(){
         FastMoney m = FastMoney.of(100, "CHF");
         assertEquals(FastMoney.of(new BigDecimal("50.0"), "CHF"), m.multiply(0.5));
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#multiply(double)}.
+     */
+    @Test
+    public void testMultiplyDoublePositiveInfinity(){
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.multiply(Double.POSITIVE_INFINITY);
+            fail("multiplying with POSITIVE_INFINITY should fail");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "multiplying with POSITIVE_INFINITY fails as expected", e);
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#multiply(double)}.
+     */
+    @Test
+    public void testMultiplyDoubleNegativeInfinity(){
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.multiply(Double.NEGATIVE_INFINITY);
+            fail("multiplying with NEGATIVE_INFINITY should fail");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "multiplying with NEGATIVE_INFINITY fails as expected", e);
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#multiply(double)}.
+     */
+    @Test
+    public void testMultiplyDoubleNaN(){
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.multiply(Double.NaN);
+            fail("multiplying with NaN should fail");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "multiplying with NaN fails as expected", e);
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#multiply(Number)}.
+     */
+    @Test
+    public void testMultiplyNumberPositiveInfinity(){
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.multiply(Double.valueOf(Double.POSITIVE_INFINITY));
+            fail("multiplying with POSITIVE_INFINITY should fail");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "multiplying with POSITIVE_INFINITY fails as expected", e);
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#multiply(Number)}.
+     */
+    @Test
+    public void testMultiplyNumberNegativeInfinity(){
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.multiply(Double.valueOf(Double.NEGATIVE_INFINITY));
+            fail("multiplying with NEGATIVE_INFINITY should fail");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "multiplying with NEGATIVE_INFINITY fails as expected", e);
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#multiply(Number)}.
+     */
+    @Test
+    public void testMultiplyNumberNaN(){
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.multiply(Double.valueOf(Double.NaN));
+            fail("multiplying with NaN should fail");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "multiplying with NaN fails as expected", e);
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#divide(double)}.
+     */
+    @Test
+    public void testDivideBadNaN(){
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.divide(Double.NaN);
+            fail("dividing by NaN should not be allowed");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "dividing by NaN fails as expected", e);
+        }
+        try {
+            m.divide(Double.valueOf(Double.NaN));
+            fail("dividing by h NaN should not be allowed");
+        } catch (ArithmeticException e) {
+            LOG.log(Level.FINE, "dividing by NaN fails as expected", e);
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#divide(double)}.
+     */
+    @Test
+    public void testDivideInfinityDoubles(){
+        double[] values = new double[]{Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};
+        FastMoney m = FastMoney.of(new BigDecimal("50.0"), "USD");
+        for (double d : values) {
+            assertTrue(m.divide(d).isZero());
+            assertTrue(m.divide(Double.valueOf(d)).isZero());
+        }
     }
 
     /**

--- a/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -525,6 +525,67 @@ public class MoneyTest{
         assertEquals(Money.of(200, "CHF"), m.multiply(2));
         assertEquals(Money.of(new BigDecimal("50.0"), "CHF"), m.multiply(0.5));
     }
+    
+
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.Money#multiply(double)}.
+     */
+    @Test
+    public void testMultiplyBadDoubles(){
+        double[] values = new double[]{
+                Double.POSITIVE_INFINITY,
+                Double.NEGATIVE_INFINITY,
+                Double.NaN};
+        Money m = Money.of(new BigDecimal("50.0"), "USD");
+        for (double d : values) {
+            try {
+                m.multiply(d);
+                fail("multiplying with:" + d + "should not be allowed");
+            } catch (ArithmeticException e) {
+                // should reach here
+            }
+            try {
+                m.multiply(Double.valueOf(d));
+                fail("multiplying with:" + d + "should not be allowed");
+            } catch (ArithmeticException e) {
+                // should reach here
+            }
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.Money#divide(double)}.
+     */
+    @Test
+    public void testDivideBadDoubles(){
+        Money m = Money.of(new BigDecimal("50.0"), "USD");
+        try {
+            m.divide(Double.NaN);
+            fail("dividing with:NaN should not be allowed");
+        } catch (ArithmeticException e) {
+            // should reach here
+        }
+        try {
+            m.divide(Double.valueOf(Double.NaN));
+            fail("dividing with NaN should not be allowed");
+        } catch (ArithmeticException e) {
+            // should reach here
+        }
+    }
+    
+    /**
+     * Test method for {@link org.javamoney.moneta.Money#divide(double)}.
+     */
+    @Test
+    public void testDivideInfinityDoubles(){
+        double[] values = new double[]{Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};
+        Money m = Money.of(new BigDecimal("50.0"), "USD");
+        for (double d : values) {
+            assertTrue(m.divide(d).isZero());
+            assertTrue(m.divide(Double.valueOf(d)).isZero());
+        }
+    }
 
     /**
      * Test method for {@link org.javamoney.moneta.Money#negate()}.


### PR DESCRIPTION
Add Tests for passing the special doubles POSITIVE_INFINITY,
NEGATIVE_INFINITY and NaN to #multiply and #divide.

 * multiplying with POSITIVE_INFINITY should throw ArithmeticException
   because it overflows
 * multiplying with NEGATIVE_INFINITY should throw ArithmeticException
   because it overflows
 * multiplying with NaN should throw ArithmeticException
 * dividing by POSITIVE_INFINITY should return 0
 * dividing by NEGATIVE_INFINITY should return 0
 * dividing by NaN should throw ArithmeticException

For FastMoney:

 * multiplying with POSITIVE_INFINITY returns the biggest possible
  FastMoney because Math.round rounds POSITIVE_INFINITY to
  Long.MAX_VALUE
 * multiplying with NEGATIVE_INFINITY returns the smallest possible
  FastMoney because Math.round rounds NEGATIVE_INFINITY to
  Long.MIN_VALUE
 * dividing by NaN returns 0 because Math.round rounds NaN to 0

For Money:

 * multiplying with any of the three throws NumberFormatException
   because their string representation can not be parsed
 * dividing by any of the three throws NumberFormatException
   because their string representation can not be parsed

This commit contains failing tests.

There are still issues untested related to using Math.round in
FastMoney.multiply. For example multiplying 90000000000000L with
90000000000000L will overflow and throw ArithmeticException. However
multiplying 90000000000000L * 90000000000000d will be rounded to
Long.MAX_VALUE.