### PR TITLE
Fix a Typo ConvertBigDecimal#DEFAULT

### DIFF
--- a/src/main/java/org/javamoney/moneta/spi/ConvertBigDecimal.java
+++ b/src/main/java/org/javamoney/moneta/spi/ConvertBigDecimal.java
@@ -75,7 +75,7 @@ public enum ConvertBigDecimal {
 			return isScaleZero(result);
 		}
 	},
-    /** Default conversion based on String, if everything else ffailed. */
+    /** Default conversion based on String, if everything else failed. */
 	DEFAULT {
 		@Override
 		BigDecimal getDecimal(Number num) {


### PR DESCRIPTION
Fix a typo in `org.javamoney.moneta.spi.ConvertBigDecimal#DEFAULT`.
