### PR TITLE
Fix a structure of pom.xml that Eclipse and IDEA IDEs were complaining about.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,72 +370,74 @@
             </extension>
         </extensions>
 
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <configuration></configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>3.0.4</version>
-                                </requireMavenVersion>
-                                <requireJavaVersion>
-                                    <version>1.7.0</version>
-                                </requireJavaVersion>
-                                <!-- <bannedDependencies> <excludes> <exclude>commons-logging:*</exclude>
-                                    </excludes> </bannedDependencies> -->
-                                <requirePluginVersions>
-                                    <banLatest>true</banLatest>
-                                    <banRelease>true</banRelease>
-                                    <banSnapshots>true</banSnapshots>
-                                    <!-- <unCheckedPluginList>org.codehaus.mojo:sonar-maven-plugin</unCheckedPluginList> -->
-                                </requirePluginVersions>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- ======================================================= -->
-            <!-- Packaging (OSGi bundle) -->
-            <!-- ======================================================= -->
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.2.201409121644</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+		<pluginManagement>
+	        <plugins>
+	            <plugin>
+	                <groupId>org.codehaus.mojo</groupId>
+	                <artifactId>versions-maven-plugin</artifactId>
+	                <configuration></configuration>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-release-plugin</artifactId>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-enforcer-plugin</artifactId>
+	                <executions>
+	                    <execution>
+	                        <id>enforce-versions</id>
+	                        <goals>
+	                            <goal>enforce</goal>
+	                        </goals>
+	                        <configuration>
+	                            <rules>
+	                                <requireMavenVersion>
+	                                    <version>3.0.4</version>
+	                                </requireMavenVersion>
+	                                <requireJavaVersion>
+	                                    <version>1.7.0</version>
+	                                </requireJavaVersion>
+	                                <!-- <bannedDependencies> <excludes> <exclude>commons-logging:*</exclude>
+	                                    </excludes> </bannedDependencies> -->
+	                                <requirePluginVersions>
+	                                    <banLatest>true</banLatest>
+	                                    <banRelease>true</banRelease>
+	                                    <banSnapshots>true</banSnapshots>
+	                                    <!-- <unCheckedPluginList>org.codehaus.mojo:sonar-maven-plugin</unCheckedPluginList> -->
+	                                </requirePluginVersions>
+	                            </rules>
+	                        </configuration>
+	                    </execution>
+	                </executions>
+	            </plugin>
+	            <!-- ======================================================= -->
+	            <!-- Packaging (OSGi bundle) -->
+	            <!-- ======================================================= -->
+	            <plugin>
+	                <groupId>org.apache.felix</groupId>
+	                <artifactId>maven-bundle-plugin</artifactId>
+	            </plugin>
+	
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-jar-plugin</artifactId>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.jacoco</groupId>
+	                <artifactId>jacoco-maven-plugin</artifactId>
+	                <version>0.7.2.201409121644</version>
+	                <executions>
+	                    <execution>
+	                        <id>prepare-agent</id>
+	                        <goals>
+	                            <goal>prepare-agent</goal>
+	                        </goals>
+	                    </execution>
+	                </executions>
+	            </plugin>
+	        </plugins>
+        </pluginManagement>
     </build>
 
     <reporting>


### PR DESCRIPTION
An additional <pluginManagement> section was added to the build section of the pom.xml in order to solve “Plugin execution not covered by lifecycle configuration" error generated by Eclipse. IDEA did also stop complaining about jacoco-maven-plugin after this change.
Effectively there are just two lines were added to the pom.xml: <pluginManagement> and </pluginManagement>
For the details on the error, please see http://stackoverflow.com/questions/6352208/how-to-solve-plugin-execution-not-covered-by-lifecycle-configuration-for-sprin
