### PR TITLE
stack overflow in test of custom exchange rate equals

### DIFF
--- a/src/test/java/org/javamoney/moneta/function/ExchangeRateSimpleTest.java
+++ b/src/test/java/org/javamoney/moneta/function/ExchangeRateSimpleTest.java
@@ -1,0 +1,36 @@
+package org.javamoney.moneta.function;
+
+import org.javamoney.moneta.ExchangeRateBuilder;
+import org.javamoney.moneta.spi.DefaultNumberValue;
+import org.testng.annotations.Test;
+
+import javax.money.CurrencyUnit;
+import javax.money.MonetaryCurrencies;
+import javax.money.convert.ExchangeRate;
+import javax.money.convert.RateType;
+
+import static org.testng.Assert.assertEquals;
+
+public class ExchangeRateSimpleTest {
+    private static final CurrencyUnit EUR = MonetaryCurrencies.getCurrency("EUR");
+    private static final CurrencyUnit GBP = MonetaryCurrencies.getCurrency("GBP");
+
+    @Test
+    public void equalsTest() {
+        DefaultNumberValue factor = new DefaultNumberValue(1.1);
+
+        ExchangeRate rate1 = new ExchangeRateBuilder("myprovider", RateType.ANY)
+                .setBase(EUR)
+                .setTerm(GBP)
+                .setFactor(factor)
+                .build();
+
+        ExchangeRate rate2 = new ExchangeRateBuilder("myprovider", RateType.ANY)
+                .setBase(EUR)
+                .setTerm(GBP)
+                .setFactor(factor)
+                .build();
+
+        assertEquals(rate1, rate2);
+    }
+}


### PR DESCRIPTION
When comparing two custom exchange rates, StackOverflowError is raised.
I suspect DefaultExchangeRate:145 together with implementation of 'equals' is the cause.
BTW: mvn clean install finishes successfully despite test errors.