### PR TITLE
Added no-args constructor to Money and FastMoney for compatibility with database tech

### DIFF
--- a/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -127,6 +127,12 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
      */
     private static final BigDecimal MIN_BD = MIN_VALUE.getBigDecimal();
 
+    /**
+     * For compatibility with database technologies that require a no-args constructor (i.e., Morphia).
+     * 
+     * @see https://github.com/mongodb/morphia/wiki/EntityAnnotation#name--constructor
+     */
+    private FastMoney() {}
 
     /**
      * Creates a new instance os {@link FastMoney}.

--- a/src/main/java/org/javamoney/moneta/Money.java
+++ b/src/main/java/org/javamoney/moneta/Money.java
@@ -92,6 +92,13 @@ public final class Money implements MonetaryAmount, Comparable<MonetaryAmount>, 
      * The numeric part of this amount.
      */
     private final BigDecimal number;
+    
+    /**
+     * For compatibility with database technologies that require a no-args constructor (i.e., Morphia).
+     * 
+     * @see https://github.com/mongodb/morphia/wiki/EntityAnnotation#name--constructor
+     */
+    private Money() {}
 
     /**
      * Creates a new instance os {@link Money}.


### PR DESCRIPTION
Some database technologies require objects to have a no-args constructor (which can even be private).

Here is the exception thrown when one tries to save FastMoney in a MongoDB database using Morphia to map between Java objects and MongoDB documents:
`org.mongodb.morphia.mapping.MappingException: No usable constructor for org.javamoney.moneta.FastMoney`

And here is its documentation saying it needs a no-args constructor:
https://github.com/mongodb/morphia/wiki/EntityAnnotation#name--constructor