### PR TITLE
Fix inconsistent naming of exchange rate classes

### DIFF
--- a/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
+++ b/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
@@ -92,7 +92,7 @@ final class BuildableCurrencyUnit implements CurrencyUnit, Comparable<CurrencyUn
     }
 
     @Override
-    public int compareTo(@SuppressWarnings("NullableProblems") CurrencyUnit o) {
+    public int compareTo(CurrencyUnit o) {
         Objects.requireNonNull(o);
         return this.currencyCode.compareTo(o.getCurrencyCode());
     }

--- a/src/main/java/org/javamoney/moneta/internal/DefaultCashRounding.java
+++ b/src/main/java/org/javamoney/moneta/internal/DefaultCashRounding.java
@@ -33,7 +33,8 @@ import java.util.Optional;
  */
 final class DefaultCashRounding implements MonetaryRounding, Serializable {
 
-    /**
+	private static final long serialVersionUID = -117584984073879922L;
+	/**
      * The scale key to be used.
      */
     private static final String SCALE_KEY = "scale";

--- a/src/main/java/org/javamoney/moneta/internal/DefaultRounding.java
+++ b/src/main/java/org/javamoney/moneta/internal/DefaultRounding.java
@@ -35,7 +35,9 @@ import java.util.Optional;
  */
 final class DefaultRounding implements MonetaryRounding, Serializable {
 
-    /**
+	private static final long serialVersionUID = -211054408229261721L;
+
+	/**
      * The scale key to be used.
      */
     private static final String SCALE_KEY = "scale";

--- a/src/main/java/org/javamoney/moneta/internal/PriorityAwareServiceProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/PriorityAwareServiceProvider.java
@@ -35,7 +35,7 @@ public class PriorityAwareServiceProvider implements ServiceProvider {
     /**
      * List of services loaded, per class.
      */
-    private final ConcurrentHashMap<Class, List<Object>> servicesLoaded = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Class<?>, List<Object>> servicesLoaded = new ConcurrentHashMap<>();
 
     /**
      * Returns a priority value of 10.

--- a/src/main/java/org/javamoney/moneta/internal/convert/ECBAbstractRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/ECBAbstractRateProvider.java
@@ -49,10 +49,10 @@ import org.javamoney.moneta.spi.LoaderService.LoaderListener;
  *
  * @author otaviojava
  */
-abstract class AbstractECBRateProvider extends AbstractRateProvider implements
+abstract class ECBAbstractRateProvider extends AbstractRateProvider implements
         LoaderListener {
 
-	private static final Logger LOG = Logger.getLogger(AbstractECBRateProvider.class.getName());
+	private static final Logger LOG = Logger.getLogger(ECBAbstractRateProvider.class.getName());
 
     private static final String BASE_CURRENCY_CODE = "EUR";
 
@@ -72,7 +72,7 @@ abstract class AbstractECBRateProvider extends AbstractRateProvider implements
 
     private final ProviderContext context;
 
-    AbstractECBRateProvider(ProviderContext context) {
+    ECBAbstractRateProvider(ProviderContext context) {
         super(context);
 		this.context = context;
         saxParserFactory.setNamespaceAware(false);
@@ -89,7 +89,7 @@ abstract class AbstractECBRateProvider extends AbstractRateProvider implements
         final int oldSize = this.rates.size();
         try {
             SAXParser parser = saxParserFactory.newSAXParser();
-            parser.parse(is, new RateECBReadingHandler(rates, getContext()));
+            parser.parse(is, new ECBRateReadingHandler(rates, getContext()));
         } catch (Exception e) {
         	LOG.log(Level.FINEST, "Error during data load.", e);
         }

--- a/src/main/java/org/javamoney/moneta/internal/convert/ECBCurrentRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/ECBCurrentRateProvider.java
@@ -30,7 +30,7 @@ import javax.money.convert.RateType;
  * @author Werner Keil
  * @author otaviojava
  */
-public class ECBCurrentRateProvider extends AbstractECBRateProvider {
+public class ECBCurrentRateProvider extends ECBAbstractRateProvider {
 
     /**
      * The data id used for the LoaderService.

--- a/src/main/java/org/javamoney/moneta/internal/convert/ECBHistoric90RateProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/ECBHistoric90RateProvider.java
@@ -38,7 +38,7 @@ import javax.money.convert.RateType;
  * @author Werner Keil
  * @author otaviojava
  */
-public class ECBHistoric90RateProvider extends AbstractECBRateProvider {
+public class ECBHistoric90RateProvider extends ECBAbstractRateProvider {
 
 
     private static final String DATA_ID = ECBHistoric90RateProvider.class.getSimpleName();

--- a/src/main/java/org/javamoney/moneta/internal/convert/ECBHistoricRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/ECBHistoricRateProvider.java
@@ -39,7 +39,7 @@ import javax.money.convert.RateType;
  * @author Werner Keil
  * @author otaviojava
  */
-public class ECBHistoricRateProvider extends AbstractECBRateProvider {
+public class ECBHistoricRateProvider extends ECBAbstractRateProvider {
 
     /**
      * The data id used for the LoaderService.

--- a/src/main/java/org/javamoney/moneta/internal/convert/ECBRateReadingHandler.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/ECBRateReadingHandler.java
@@ -38,7 +38,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * @author Anatole Tresch
  * @author otaviojava
  */
-class RateECBReadingHandler extends DefaultHandler {
+class ECBRateReadingHandler extends DefaultHandler {
     /**
      * Current timestamp for the given section.
      */
@@ -53,7 +53,7 @@ class RateECBReadingHandler extends DefaultHandler {
      * @param historicRates the rates, not null.
      * @param context the context, not null.
      */
-    RateECBReadingHandler(Map<LocalDate, Map<String, ExchangeRate>> historicRates, ProviderContext context) {
+    ECBRateReadingHandler(Map<LocalDate, Map<String, ExchangeRate>> historicRates, ProviderContext context) {
         this.historicRates = historicRates;
         this.context = context;
     }

--- a/src/main/java/org/javamoney/moneta/internal/convert/IMFAbstractRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/IMFAbstractRateProvider.java
@@ -28,14 +28,14 @@ import javax.money.convert.ProviderContext;
 
 import org.javamoney.moneta.CurrencyUnitBuilder;
 import org.javamoney.moneta.ExchangeRateBuilder;
-import org.javamoney.moneta.internal.convert.RateIMFReadingHandler.RateIMFResult;
+import org.javamoney.moneta.internal.convert.IMFRateReadingHandler.RateIMFResult;
 import org.javamoney.moneta.spi.AbstractRateProvider;
 import org.javamoney.moneta.spi.LoaderService.LoaderListener;
 
-abstract class AbstractIMFRateProvider extends AbstractRateProvider implements LoaderListener {
+abstract class IMFAbstractRateProvider extends AbstractRateProvider implements LoaderListener {
 
 
-    private static final Logger LOG = Logger.getLogger(AbstractIMFRateProvider.class.getName());
+    private static final Logger LOG = Logger.getLogger(IMFAbstractRateProvider.class.getName());
 
     static final Comparator<ExchangeRate> COMPARATOR_EXCHANGE_BY_LOCAL_DATE = Comparator.comparing(c -> c.getContext().get(LocalDate.class));
 
@@ -49,14 +49,14 @@ abstract class AbstractIMFRateProvider extends AbstractRateProvider implements L
 
 	protected Map<CurrencyUnit, List<ExchangeRate>> sdrToCurrency = Collections.emptyMap();
 
-	protected final RateIMFReadingHandler handler;
+	protected final IMFRateReadingHandler handler;
 
 	private final ProviderContext context;
 
-	public AbstractIMFRateProvider(ProviderContext providerContext) {
+	public IMFAbstractRateProvider(ProviderContext providerContext) {
 		super(providerContext);
 		this.context = providerContext;
-		handler = new RateIMFReadingHandler(CURRENCIES_BY_NAME, context);
+		handler = new IMFRateReadingHandler(CURRENCIES_BY_NAME, context);
 	}
 
 

--- a/src/main/java/org/javamoney/moneta/internal/convert/IMFHistoricRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/IMFHistoricRateProvider.java
@@ -21,10 +21,10 @@ import javax.money.convert.ProviderContextBuilder;
 import javax.money.convert.RateType;
 import javax.money.spi.Bootstrap;
 
-import org.javamoney.moneta.internal.convert.RateIMFReadingHandler.RateIMFResult;
+import org.javamoney.moneta.internal.convert.IMFRateReadingHandler.RateIMFResult;
 import org.javamoney.moneta.spi.LoaderService;
 
-public class IMFHistoricRateProvider extends AbstractIMFRateProvider {
+public class IMFHistoricRateProvider extends IMFAbstractRateProvider {
 
     private static final Logger LOG = Logger.getLogger(IMFHistoricRateProvider.class.getName());
 

--- a/src/main/java/org/javamoney/moneta/internal/convert/IMFRateProvider.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/IMFRateProvider.java
@@ -36,7 +36,7 @@ import org.javamoney.moneta.spi.LoaderService;
  * @author Anatole Tresch
  * @author Werner Keil
  */
-public class IMFRateProvider extends AbstractIMFRateProvider {
+public class IMFRateProvider extends IMFAbstractRateProvider {
 
 	private static final Logger LOG = Logger
 			.getLogger(IMFRateProvider.class.getName());

--- a/src/main/java/org/javamoney/moneta/internal/convert/IMFRateReadingHandler.java
+++ b/src/main/java/org/javamoney/moneta/internal/convert/IMFRateReadingHandler.java
@@ -25,16 +25,16 @@ import javax.money.convert.RateType;
 import org.javamoney.moneta.ExchangeRateBuilder;
 import org.javamoney.moneta.spi.DefaultNumberValue;
 
-class RateIMFReadingHandler {
+class IMFRateReadingHandler {
 
 	private static final Logger LOG = Logger
-			.getLogger(RateIMFReadingHandler.class.getName());
+			.getLogger(IMFRateReadingHandler.class.getName());
 
 	private final Map<String, CurrencyUnit> currenciresByName;
 
 	private final ProviderContext context;
 
-	RateIMFReadingHandler(Map<String, CurrencyUnit> currenciresByName, ProviderContext context) {
+	IMFRateReadingHandler(Map<String, CurrencyUnit> currenciresByName, ProviderContext context) {
 		this.currenciresByName = currenciresByName;
 		this.context = context;
 	}
@@ -146,7 +146,7 @@ class RateIMFReadingHandler {
 				ExchangeRate rate = new ExchangeRateBuilder(
 						ConversionContextBuilder.create(context, rateType)
 								.set(fromTS).build()).setBase(currency)
-						.setTerm(AbstractIMFRateProvider.SDR)
+						.setTerm(IMFAbstractRateProvider.SDR)
 						.setFactor(new DefaultNumberValue(1D / values[index]))
 						.build();
 				List<ExchangeRate> rates = currencyToSdr.computeIfAbsent(
@@ -155,7 +155,7 @@ class RateIMFReadingHandler {
 			} else {
 				ExchangeRate rate = new ExchangeRateBuilder(
 						ConversionContextBuilder.create(context, rateType)
-								.set(fromTS).build()).setBase(AbstractIMFRateProvider.SDR)
+								.set(fromTS).build()).setBase(IMFAbstractRateProvider.SDR)
 						.setTerm(currency)
 						.setFactor(DefaultNumberValue.of(1D / values[index]))
 						.build();
@@ -224,7 +224,7 @@ class RateIMFReadingHandler {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(RateIMFReadingHandler.class.getName()).append('{').append(" currenciresByName: ").append(currenciresByName).append(',')
+		sb.append(IMFRateReadingHandler.class.getName()).append('{').append(" currenciresByName: ").append(currenciresByName).append(',')
 		.append(" context: ").append(context).append('}');
 		return sb.toString();
 	}

--- a/src/main/java/org/javamoney/moneta/internal/format/CurrencyToken.java
+++ b/src/main/java/org/javamoney/moneta/internal/format/CurrencyToken.java
@@ -228,7 +228,6 @@ final class CurrencyToken implements FormatToken {
      * @return the first letter based part, or the full token.
      */
     private String parseCurrencyCode(String token) {
-        StringBuilder builder = new StringBuilder();
         int letterIndex = 0;
         for (char ch : token.toCharArray()) {
             if (Character.isLetter(ch)) {

--- a/src/test/java/org/javamoney/moneta/spi/ConvertBigDecimalTest.java
+++ b/src/test/java/org/javamoney/moneta/spi/ConvertBigDecimalTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 /**
  * Tests for {@link org.javamoney.moneta.spi.ConvertBigDecimal}.
  */
-@SuppressWarnings("BigDecimalMethodWithoutRoundingCalled")
 public class ConvertBigDecimalTest {
 
 	private final BigDecimal expectValue = BigDecimal.TEN;
@@ -52,22 +51,22 @@ public class ConvertBigDecimalTest {
 	public void ofByteTest() {
 		Assert.assertEquals(ConvertBigDecimal.of((byte) 10), expectValue);
 	}
-	
+
 	@Test
 	public void ofAtomicLongTest() {
 		Assert.assertEquals(ConvertBigDecimal.of(new AtomicLong(10l)), expectValue);
 	}
-	
+
 	@Test
 	public void ofAtomicIntegerTest() {
 		Assert.assertEquals(ConvertBigDecimal.of(new AtomicInteger(10)), expectValue);
 	}
-	
+
 	@Test
 	public void ofFloatTest() {
 		Assert.assertEquals(ConvertBigDecimal.of(10f).setScale(0), expectValue);
 	}
-	
+
 	@Test
 	public void ofDoubleTest() {
 		Assert.assertEquals(ConvertBigDecimal.of(10d).setScale(0), expectValue);


### PR DESCRIPTION
Fix inconsistent naming of exchange rate classes