### PR TITLE
verifies if the policy read is never, to read directly from callback.

### DIFF
--- a/src/main/java/org/javamoney/moneta/internal/loader/LoadableResource.java
+++ b/src/main/java/org/javamoney/moneta/internal/loader/LoadableResource.java
@@ -145,12 +145,16 @@ public class LoadableResource {
             clearCache();
         }
         if (!readCache()) {
-            if (loadRemote()) {
+            if (shouldReadDataFromCallBack()) {
                 return loadFallback();
             }
         }
         return true;
     }
+
+	private boolean shouldReadDataFromCallBack() {
+		return LoaderService.UpdatePolicy.NEVER.equals(updatePolicy) || !loadRemote();
+	}
 
     /**
      * Get the resourceId.
@@ -363,7 +367,7 @@ public class LoadableResource {
                 synchronized (lock) {
                     currentData = this.data == null ? null : this.data.get();
                     if (Objects.isNull(currentData)) {
-                        if (loadRemote()) {
+                        if (shouldReadDataFromCallBack()) {
                             loadFallback();
                         }
                     }


### PR DESCRIPTION
Verifies if the policy read is `NEVER`, to read directly from callback.
To load from callback before, was just if happened an error on remote, now the code checks if the policy read is `NEVER`.