### PR TITLE
give getNumberType() an upper-bound of Number

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/DefaultNumberValue.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/DefaultNumberValue.java
@@ -65,7 +65,7 @@ public final class DefaultNumberValue extends NumberValue {
      * @see javax.money.NumberValue#getNumberType()
      */
     @Override
-    public Class<?> getNumberType() {
+    public Class<? extends Number> getNumberType() {
         return this.number.getClass();
     }
 


### PR DESCRIPTION
We’re allowed to make `getNumberType()` more specific in the subclass
(covariance) and since `DefaultNumberValue` requires that its internal
format be a `Number`, we should specify the more narrow return type.

This PR is related to https://github.com/JavaMoney/jsr354-api/pull/52. According to the Specification `NumberValue.getNumberType()` (API) may return a class that doesn't extend `Number` so that PR should probably be rejected. However, `DefaultNumberValue.getNumberType()` (RI) can and should guarantee the returned class extends `Number`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/129)
<!-- Reviewable:end -->
