### PR TITLE
load resources via HTTPS by default

### DIFF
--- a/src/main/resources/javamoney.properties
+++ b/src/main/resources/javamoney.properties
@@ -26,14 +26,14 @@
 {-1}load.ECBCurrentRateProvider.type=SCHEDULED
 {-1}load.ECBCurrentRateProvider.period=03:00
 {-1}load.ECBCurrentRateProvider.resource=/java-money/defaults/ECB/eurofxref-daily.xml
-{-1}load.ECBCurrentRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
+{-1}load.ECBCurrentRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 {-1}load.ECBCurrentRateProvider.startRemote=true
 
 {-1}load.ECBHistoric90RateProvider.type=SCHEDULED
 {-1}load.ECBHistoric90RateProvider.period=03:00
 #{-1}load.ECBHistoric90RateProvider.at=12:00
 {-1}load.ECBHistoric90RateProvider.resource=/java-money/defaults/ECB/eurofxref-hist-90d.xml
-{-1}load.ECBHistoric90RateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
+{-1}load.ECBHistoric90RateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
 {-1}load.ECBHistoric90RateProvider.startRemote=true
 
 {-1}load.ECBHistoricRateProvider.type=SCHEDULED
@@ -41,7 +41,7 @@
 {-1}load.ECBHistoricRateProvider.delay=01:00
 {-1}load.ECBHistoricRateProvider.at=07:00
 {-1}load.ECBHistoricRateProvider.resource=/java-money/defaults/ECB/eurofxref-hist.xml
-{-1}load.ECBHistoricRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
+{-1}load.ECBHistoricRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
 {-1}load.ECBHistoricRateProvider.startRemote=false
 
 {-1}ecb.digit.fraction=6
@@ -51,12 +51,12 @@
 #{-1}load.IMFRateProvider.delay=12:00
 #{-1}load.IMFRateProvider.at=12:00
 {-1}load.IMFRateProvider.resource=/java-money/defaults/IMF/rms_five.xls
-{-1}load.IMFRateProvider.urls=http://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
+{-1}load.IMFRateProvider.urls=https://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
 {-1}load.IMFRateProvider.startRemote=true
 
 {-1}load.IMFHistoricRateProvider.type=LAZY
 {-1}load.IMFHistoricRateProvider.resource=/java-money/defaults/IMF/rms_five.xls
-{-1}load.IMFHistoricRateProvider.urls=http://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
+{-1}load.IMFHistoricRateProvider.urls=https://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
 {-1}load.IMFHistoricRateProvider.startRemote=true
 {-1}imf.digit.fraction=6
 


### PR DESCRIPTION
Ignore this pull request if HTTP is used due to performance considerations. But even then.. others could overwrite for lesser security.. what do you think?