### PR TITLE
Use plain number formatting for Money.toString

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/Money.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/Money.java
@@ -655,7 +655,7 @@ public final class Money implements MonetaryAmount, Comparable<MonetaryAmount>, 
      */
     @Override
     public String toString() {
-        return getCurrency().getCurrencyCode() + ' ' + number.toString();
+        return getCurrency().getCurrencyCode() + ' ' + number.toPlainString();
     }
 
     /*

--- a/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -1085,6 +1085,8 @@ public class MoneyTest {
         assertEquals("CHF 1234", Money.of(new BigDecimal("1234.0"), "CHF").toString());
         assertEquals("CHF 1234.1", Money.of(new BigDecimal("1234.1"), "CHF").toString());
         assertEquals("CHF 0.01", Money.of(new BigDecimal("0.0100"), "CHF").toString());
+        assertEquals("CHF 50",
+            Money.of(new BigDecimal("500").multiply(new BigDecimal(".1")), "CHF").toString());
     }
 
     /**


### PR DESCRIPTION
This fixes #144, preventing BIgDecimal from rendering the numeric part of
the amount in exponent notation if the amount's BigDecimal value was computed
in certain ways. It will now always render "CHF 50" instead of "CHF 5E+1".