### PR TITLE
GH-158 Uses static method initializer in JDKCurrencyProvider

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/JDKCurrencyProvider.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/JDKCurrencyProvider.java
@@ -26,7 +26,7 @@ import javax.money.spi.CurrencyProviderSpi;
 /**
  * Default implementation of a {@link CurrencyUnit} based on the using the JDK's
  * {@link Currency}.
- * 
+ *
  * @version 0.5.1
  * @author Anatole Tresch
  * @author Werner Keil
@@ -34,14 +34,17 @@ import javax.money.spi.CurrencyProviderSpi;
 public class JDKCurrencyProvider implements CurrencyProviderSpi {
 
 	/** Internal shared cache of {@link javax.money.CurrencyUnit} instances. */
-	private static final Map<String, CurrencyUnit> CACHED = new HashMap<>();
+    private static final Map<String, CurrencyUnit> CACHED = loadCurrencies();
 
-	public JDKCurrencyProvider() {
-		for (Currency jdkCurrency : Currency.getAvailableCurrencies()) {
-			CurrencyUnit cu = new JDKCurrencyAdapter(jdkCurrency);
-			CACHED.put(cu.getCurrencyCode(), cu);
-		}
-	}
+    private static Map<String, CurrencyUnit> loadCurrencies() {
+        Set<Currency> availableCurrencies = Currency.getAvailableCurrencies();
+        Map<String, CurrencyUnit> result = new HashMap<>(availableCurrencies.size());
+        for (Currency jdkCurrency : availableCurrencies) {
+            CurrencyUnit cu = new JDKCurrencyAdapter(jdkCurrency);
+            result.put(cu.getCurrencyCode(), cu);
+        }
+        return Collections.unmodifiableMap(result);
+    }
 
     @Override
     public String getProviderName(){


### PR DESCRIPTION
Fixes #158 

The cache for currency units should be initialized once on class load but was repopulated in constructor each time new instance is created. This PR makes initialization static.

The workaround https://github.com/JavaMoney/jsr354-ri/issues/158#issuecomment-313672702 worked probably because second and folllowing repopulations of cache in fact did not introduce new key-value pairs so there was no resize of hashmap.