### PR TITLE
Fix 0A character problem in currency parser/formatter

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
@@ -15,9 +15,11 @@
  */
 package org.javamoney.moneta.internal.format;
 
-import org.javamoney.moneta.Money;
 import org.javamoney.moneta.format.AmountFormatParams;
 
+import javax.money.MonetaryAmount;
+import javax.money.format.AmountFormatContext;
+import javax.money.format.MonetaryParseException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
@@ -26,11 +28,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
-
-import javax.money.MonetaryAmount;
-import javax.money.format.AmountFormatContext;
-import javax.money.format.MonetaryFormats;
-import javax.money.format.MonetaryParseException;
 
 /**
  * {@link FormatToken} which allows to format a {@link MonetaryAmount} type.

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
@@ -15,6 +15,7 @@
  */
 package org.javamoney.moneta.internal.format;
 
+import org.javamoney.moneta.Money;
 import org.javamoney.moneta.format.AmountFormatParams;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.util.logging.Logger;
 
 import javax.money.MonetaryAmount;
 import javax.money.format.AmountFormatContext;
+import javax.money.format.MonetaryFormats;
 import javax.money.format.MonetaryParseException;
 
 /**
@@ -61,8 +63,15 @@ final class AmountNumberToken implements FormatToken {
             formatFormat.setDecimalFormatSymbols(syms);
             parseFormat.setDecimalFormatSymbols(syms);
         }
-        formatFormat.applyPattern(this.partialNumberPattern);
-        parseFormat.applyPattern(this.partialNumberPattern.trim());
+        formatFormat.applyPattern(removeNBSP(partialNumberPattern));
+        parseFormat.applyPattern(removeNBSP(partialNumberPattern).trim());
+    }
+
+    /**
+     * Removes the non-breaking-space character 0x0A from the string.
+     */
+    private String removeNBSP(String s) {
+        return s.replaceAll("\\u00A0", " ");
     }
 
     /**


### PR DESCRIPTION
There's a bug in formatting currency for some languages, like Polish. This bug is probably not visible using US locales because they don't use spaces in currency. Please try to run this code:

```java
Locale locale = new Locale("pl");
Money.parse(MonetaryFormats.getAmountFormat(locale).format(Money.of(12.13, "USD")),
    MonetaryFormats.getAmountFormat(locale));
```
The result is:

```
Exception in thread "main" javax.money.MonetaryException: Error parsing CurrencyUnit: no input.
	at org.javamoney.moneta.internal.format.CurrencyToken.parse(CurrencyToken.java:182)
	at org.javamoney.moneta.internal.format.DefaultMonetaryAmountFormat.parse(DefaultMonetaryAmountFormat.java:190)
	at org.javamoney.moneta.Money.parse(Money.java:864)
	at org.javamoney.moneta.internal.format.AmountNumberToken.main(AmountNumberToken.java:167)
```

The problem is that if default java locale provides space in currency format string, it's not `0x20` but NBSP `0x0A` character instead, and this is not removed by `partialNumberPattern.trim()` [here](https://github.com/JavaMoney/jsr354-ri/blob/cc7860fe6fdd298911a39505ca179995c7e1bfa4/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java#L65).

In my opinion using `0x0A` in formatted strings (by Java itself) can be generally harmful and can produce very hard to detect problem. I've spend two hours of debuggin why `"12,13 USD" != "12,13 USD"`, because both `0x20` and `0x0A` are displayed everywhere (in logs, in browser, in IDE debugger etc) as spaces. My proposition is to remove this character during number formatting in the lib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/181)
<!-- Reviewable:end -->
