### PR TITLE
Fixes for missing OSGi package imports and excessive runtime requirement

### DIFF
--- a/moneta-convert/moneta-convert-base/bnd.bnd
+++ b/moneta-convert/moneta-convert-base/bnd.bnd
@@ -1,12 +1,19 @@
+# Javac settings
+javac.source: 1.8
+javac.target: 1.8
+
+# Override automatic runtime requirement when building with JDK9+
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=8.0))"
+
 -buildpath: \
 	osgi.annotation; version=6.0.0,\
 	osgi.core; version=6.0,\
 	osgi.cmpn; version=6.0
 
-javac.source: 1.8
-javac.target: 1.8
-
+# JPMS
 Automatic-Module-Name: org.javamoney.moneta.convert
+
+# Bundle description
 Bundle-Version: ${project.version}.${tstamp}
 Bundle-Name: JavaMoney Moneta Conversion
 Bundle-Activator: org.javamoney.moneta.convert.internal.OSGIActivator
@@ -17,14 +24,10 @@ Bundle-Copyright: (C) Credit Suisse AG
 Bundle-License: Apache License, Version 2.0
 Bundle-Vendor: Credit Suisse AG
 Bundle-DocURL: http://www.javamoney.org
-Import-Package: \
-	javax.money,\
-    javax.money.spi,\
-    javax.money.convert
-Export-Package: \
-	org.javamoney.moneta.convert
-Private-Package: \
-	org.javamoney.moneta.convert.internal
+
+# Bundle capabilities and requirements
+Import-Package: *
+Export-Package: ${packages;NAMED;!*internal*}
 Export-Service: \
     javax.money.convert.ExchangeRateProvider,\
     javax.money.spi.MonetaryConversionsSingletonSpi

--- a/moneta-convert/moneta-convert-ecb/bnd.bnd
+++ b/moneta-convert/moneta-convert-ecb/bnd.bnd
@@ -1,3 +1,10 @@
+# Javac settings
+javac.source: 1.8
+javac.target: 1.8
+
+# Override automatic runtime requirement when building with JDK9+
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=8.0))"
+
 -buildpath: \
 	osgi.annotation; version=6.0.0,\
 	osgi.core; version=6.0,\
@@ -6,10 +13,10 @@
 -testpath: \
 	${junit}
 
-javac.source: 1.8
-javac.target: 1.8
-
+# JPMS
 Automatic-Module-Name: org.javamoney.moneta.convert.ecb
+
+# Bundle description
 Bundle-Version: ${project.version}.${tstamp}
 Bundle-Name: JavaMoney Moneta ECB Conversion
 Bundle-Activator: org.javamoney.moneta.convert.ecb.OSGIActivator
@@ -20,12 +27,8 @@ Bundle-Copyright: (C) Credit Suisse AG
 Bundle-License: Apache License, Version 2.0
 Bundle-Vendor: Credit Suisse AG
 Bundle-DocURL: http://www.javamoney.org
-Import-Package: \
-	javax.money,\
-    javax.money.spi,\
-    javax.money.convert,\
-    org.javamoney.moneta.convert
-Private-Package: \
-	org.javamoney.moneta.convert.ecb
+
+# Bundle capabilities and requirements
+Import-Package: *
 Export-Service: \
     javax.money.convert.ExchangeRateProvider

--- a/moneta-convert/moneta-convert-imf/bnd.bnd
+++ b/moneta-convert/moneta-convert-imf/bnd.bnd
@@ -1,12 +1,19 @@
+# Javac settings
+javac.source: 1.8
+javac.target: 1.8
+
+# Override automatic runtime requirement when building with JDK9+
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=8.0))"
+
 -buildpath: \
 	osgi.annotation; version=6.0.0,\
 	osgi.core; version=6.0,\
 	osgi.cmpn; version=6.0
 
-javac.source: 1.8
-javac.target: 1.8
-
+# JPMS
 Automatic-Module-Name: org.javamoney.moneta.convert.imf
+
+# Bundle description
 Bundle-Version: ${project.version}.${tstamp}
 Bundle-Name: JavaMoney Moneta IMF Conversion
 Bundle-Activator: org.javamoney.moneta.convert.imf.OSGIActivator
@@ -17,12 +24,8 @@ Bundle-Copyright: (C) Credit Suisse AG
 Bundle-License: Apache License, Version 2.0
 Bundle-Vendor: Credit Suisse AG
 Bundle-DocURL: http://www.javamoney.org
-Import-Package: \
-	javax.money,\
-    javax.money.spi,\
-    javax.money.convert,\
-    org.javamoney.moneta.convert
-Private-Package: \
-	org.javamoney.moneta.convert.imf
+
+# Bundle capabilities and requirements
+Import-Package: *
 Export-Service: \
     javax.money.convert.ExchangeRateProvider

--- a/moneta-core/bnd.bnd
+++ b/moneta-core/bnd.bnd
@@ -1,12 +1,19 @@
+# Javac settings
+javac.source: 1.8
+javac.target: 1.8
+
+# Override automatic runtime requirement when building with JDK9+
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=8.0))"
+
 -buildpath: \
 	osgi.annotation; version=6.0.0,\
 	osgi.core; version=6.0,\
 	osgi.cmpn; version=6.0
 
-javac.source: 1.8
-javac.target: 1.8
-
+# JPMS
 Automatic-Module-Name: org.javamoney.moneta
+
+# Bundle description
 Bundle-Version: ${project.version}.${tstamp}
 Bundle-Name: JavaMoney Moneta Reference Implementation
 Bundle-Activator: org.javamoney.moneta.internal.OSGIActivator
@@ -17,18 +24,10 @@ Bundle-Copyright: (C) Credit Suisse AG
 Bundle-License: Apache License, Version 2.0
 Bundle-Vendor: Credit Suisse AG
 Bundle-DocURL: http://www.javamoney.org
-Import-Package: \
-	javax.money,\
-    javax.money.spi
-Export-Package: \
-	org.javamoney.moneta,\
-    org.javamoney.moneta.format,\
-    org.javamoney.moneta.function,\
-    org.javamoney.moneta.spi
-Private-Package: \
-	org.javamoney.moneta.internal,\
-	org.javamoney.moneta.internal.format,\
-	org.javamoney.moneta.internal.loader
+
+# Bundle capabilities and requirements
+Import-Package: *
+Export-Package: ${packages;NAMED;!*internal*}
 Export-Service: \
     javax.money.spi.CurrencyProviderSpi,\
     javax.money.spi.MonetaryAmountFactoryProviderSpi,\


### PR DESCRIPTION
Motivation for wildcards and macros is to reduce OSGi target support overhead for future builds.

Added missing imports by removing explicit bnd Import-Package instruction. We now import `*` which is recommended in most cases.

Replaced explicit export header with a macro that exports everything not matching package `*internal*`. This should reduce manual maintenance of build scripts when introducing new internal or exported packages while producing the same output as the current bundle.

Removed explicit Private-Package header; bnd will produce an automatic one from what is not exported. There are more exotic use cases for this header explained elsewhere.

Override automatic bnd runtime target with `>= JavaSE-8.0`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/195)
<!-- Reviewable:end -->
