### PR TITLE
Use HTTPS for currency rate providers URLs

### DIFF
--- a/moneta-convert/moneta-convert-base/src/main/asciidoc/userguide.adoc
+++ b/moneta-convert/moneta-convert-base/src/main/asciidoc/userguide.adoc
@@ -700,20 +700,20 @@ data feeds and the (re)load/update settings:
 load.ECBCurrentRateProvider.type=SCHEDULED
 load.ECBCurrentRateProvider.period=03:00
 load.ECBCurrentRateProvider.resource=/java-money/defaults/ECB/eurofxref-daily.xml
-load.ECBCurrentRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
+load.ECBCurrentRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 
 load.ECBHistoric90RateProvider.type=SCHEDULED
 load.ECBHistoric90RateProvider.period=03:00
 #load.ECBHistoric90RateProvider.at=12:00
 load.ECBHistoric90RateProvider.resource=/java-money/defaults/ECB/eurofxref-hist-90d.xml
-load.ECBHistoric90RateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
+load.ECBHistoric90RateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
 
 load.ECBHistoricRateProvider.type=SCHEDULED
 load.ECBHistoricRateProvider.period=24:00
 load.ECBHistoricRateProvider.delay=01:00
 load.ECBHistoricRateProvider.at=07:00
 load.ECBHistoricRateProvider.resource=/java-money/defaults/ECB/eurofxref-hist.xml
-load.ECBHistoricRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
+load.ECBHistoricRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
 
 # IMF Rates
 load.IMFRateProvider.type=SCHEDULED
@@ -721,7 +721,7 @@ load.IMFRateProvider.period=06:00
 #load.IMFRateProvider.delay=12:00
 #load.IMFRateProvider.at=12:00
 load.IMFRateProvider.resource=/java-money/defaults/IMF/rms_five.xls
-load.IMFRateProvider.urls=http://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
+load.IMFRateProvider.urls=https://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
 --------------------------------------------
 
 

--- a/moneta-convert/moneta-convert-ecb/src/main/asciidoc/userguide.adoc
+++ b/moneta-convert/moneta-convert-ecb/src/main/asciidoc/userguide.adoc
@@ -700,20 +700,20 @@ data feeds and the (re)load/update settings:
 load.ECBCurrentRateProvider.type=SCHEDULED
 load.ECBCurrentRateProvider.period=03:00
 load.ECBCurrentRateProvider.resource=/java-money/defaults/ECB/eurofxref-daily.xml
-load.ECBCurrentRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
+load.ECBCurrentRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 
 load.ECBHistoric90RateProvider.type=SCHEDULED
 load.ECBHistoric90RateProvider.period=03:00
 #load.ECBHistoric90RateProvider.at=12:00
 load.ECBHistoric90RateProvider.resource=/java-money/defaults/ECB/eurofxref-hist-90d.xml
-load.ECBHistoric90RateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
+load.ECBHistoric90RateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
 
 load.ECBHistoricRateProvider.type=SCHEDULED
 load.ECBHistoricRateProvider.period=24:00
 load.ECBHistoricRateProvider.delay=01:00
 load.ECBHistoricRateProvider.at=07:00
 load.ECBHistoricRateProvider.resource=/java-money/defaults/ECB/eurofxref-hist.xml
-load.ECBHistoricRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
+load.ECBHistoricRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
 
 # IMF Rates
 load.IMFRateProvider.type=SCHEDULED
@@ -721,7 +721,7 @@ load.IMFRateProvider.period=06:00
 #load.IMFRateProvider.delay=12:00
 #load.IMFRateProvider.at=12:00
 load.IMFRateProvider.resource=/java-money/defaults/IMF/rms_five.xls
-load.IMFRateProvider.urls=http://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
+load.IMFRateProvider.urls=https://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
 --------------------------------------------
 
 

--- a/moneta-convert/moneta-convert-ecb/src/main/resources/javamoney.properties
+++ b/moneta-convert/moneta-convert-ecb/src/main/resources/javamoney.properties
@@ -20,14 +20,14 @@
 {-1}load.ECBCurrentRateProvider.type=SCHEDULED
 {-1}load.ECBCurrentRateProvider.period=03:00
 {-1}load.ECBCurrentRateProvider.resource=/java-money/defaults/ECB/eurofxref-daily.xml
-{-1}load.ECBCurrentRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
+{-1}load.ECBCurrentRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 {-1}load.ECBCurrentRateProvider.startRemote=true
 
 {-1}load.ECBHistoric90RateProvider.type=SCHEDULED
 {-1}load.ECBHistoric90RateProvider.period=03:00
 #{-1}load.ECBHistoric90RateProvider.at=12:00
 {-1}load.ECBHistoric90RateProvider.resource=/java-money/defaults/ECB/eurofxref-hist-90d.xml
-{-1}load.ECBHistoric90RateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
+{-1}load.ECBHistoric90RateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
 {-1}load.ECBHistoric90RateProvider.startRemote=true
 
 {-1}load.ECBHistoricRateProvider.type=SCHEDULED
@@ -35,7 +35,7 @@
 {-1}load.ECBHistoricRateProvider.delay=01:00
 {-1}load.ECBHistoricRateProvider.at=07:00
 {-1}load.ECBHistoricRateProvider.resource=/java-money/defaults/ECB/eurofxref-hist.xml
-{-1}load.ECBHistoricRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
+{-1}load.ECBHistoricRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
 {-1}load.ECBHistoricRateProvider.startRemote=false
 {-1}ecb.digit.fraction=6
 

--- a/moneta-convert/moneta-convert-ecb/update_ecb.sh
+++ b/moneta-convert/moneta-convert-ecb/update_ecb.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 printf "\n Downloading the ECB daily resource. \n"
-wget http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
+wget https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 mv eurofxref-daily.xml src/main/resources/java-money/defaults/ECB/eurofxref-daily.xml
 printf "\n Done. Downloading the ECB-90 resource. \n"
-wget http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
+wget https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
 mv eurofxref-hist-90d.xml src/main/resources/java-money/defaults/ECB/eurofxref-hist-90d.xml
 printf "\n Done. Downloading the ECB-hist resource. \n"
-wget http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
+wget https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
 mv eurofxref-hist.xml src/main/resources/java-money/defaults/ECB/eurofxref-hist.xml
 printf "\n Done.

--- a/moneta-convert/moneta-convert-imf/src/main/asciidoc/userguide.adoc
+++ b/moneta-convert/moneta-convert-imf/src/main/asciidoc/userguide.adoc
@@ -700,20 +700,20 @@ data feeds and the (re)load/update settings:
 load.ECBCurrentRateProvider.type=SCHEDULED
 load.ECBCurrentRateProvider.period=03:00
 load.ECBCurrentRateProvider.resource=/java-money/defaults/ECB/eurofxref-daily.xml
-load.ECBCurrentRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
+load.ECBCurrentRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 
 load.ECBHistoric90RateProvider.type=SCHEDULED
 load.ECBHistoric90RateProvider.period=03:00
 #load.ECBHistoric90RateProvider.at=12:00
 load.ECBHistoric90RateProvider.resource=/java-money/defaults/ECB/eurofxref-hist-90d.xml
-load.ECBHistoric90RateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
+load.ECBHistoric90RateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
 
 load.ECBHistoricRateProvider.type=SCHEDULED
 load.ECBHistoricRateProvider.period=24:00
 load.ECBHistoricRateProvider.delay=01:00
 load.ECBHistoricRateProvider.at=07:00
 load.ECBHistoricRateProvider.resource=/java-money/defaults/ECB/eurofxref-hist.xml
-load.ECBHistoricRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
+load.ECBHistoricRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
 
 # IMF Rates
 load.IMFRateProvider.type=SCHEDULED
@@ -721,7 +721,7 @@ load.IMFRateProvider.period=06:00
 #load.IMFRateProvider.delay=12:00
 #load.IMFRateProvider.at=12:00
 load.IMFRateProvider.resource=/java-money/defaults/IMF/rms_five.xls
-load.IMFRateProvider.urls=http://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
+load.IMFRateProvider.urls=https://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
 --------------------------------------------
 
 

--- a/moneta-convert/moneta-convert-imf/src/main/java/org/javamoney/moneta/convert/imf/IMFHistoricalType.java
+++ b/moneta-convert/moneta-convert-imf/src/main/java/org/javamoney/moneta/convert/imf/IMFHistoricalType.java
@@ -19,14 +19,13 @@ import java.time.YearMonth;
 import java.util.Objects;
 
 enum IMFHistoricalType {
+	SDR_Currency("SDRCV"), Currency_SDR("CVSDR");
 
-	 SDR_Currency("SDRCV"), Currency_SDR("CVSDR");
+	private final String type;
 
-	 private final String type;
+	private static final String HOST = "https://www.imf.org/external/np/fin/data/rms_mth.aspx?SelectDate=%s&reportType=%s&tsvflag=Y";
 
-	 private static final String HOST = "http://www.imf.org/external/np/fin/data/rms_mth.aspx?SelectDate=%s&reportType=%s&tsvflag=Y";
-
-	 IMFHistoricalType(String type) {
+	IMFHistoricalType(String type) {
 		this.type = type;
 	 }
 

--- a/moneta-convert/moneta-convert-imf/src/test/java/org/javamoney/moneta/convert/imf/IMFHistoricalTypeTest.java
+++ b/moneta-convert/moneta-convert-imf/src/test/java/org/javamoney/moneta/convert/imf/IMFHistoricalTypeTest.java
@@ -47,7 +47,7 @@ public class IMFHistoricalTypeTest {
 		YearMonth yearMonth = YearMonth.of(2015, Month.APRIL);
 		String url = IMFHistoricalType.Currency_SDR.getUrl(yearMonth);
 		Assert.assertNotNull(url);
-		Assert.assertEquals(url, "http://www.imf.org/external/np/fin/data/rms_mth.aspx?SelectDate=2015-04&reportType=CVSDR&tsvflag=Y");
+		Assert.assertEquals(url, "https://www.imf.org/external/np/fin/data/rms_mth.aspx?SelectDate=2015-04&reportType=CVSDR&tsvflag=Y");
 	}
 
 	@Test
@@ -55,6 +55,6 @@ public class IMFHistoricalTypeTest {
 		YearMonth yearMonth = YearMonth.of(2015, Month.APRIL);
 		String url = IMFHistoricalType.SDR_Currency.getUrl(yearMonth);
 		Assert.assertNotNull(url);
-		Assert.assertEquals(url, "http://www.imf.org/external/np/fin/data/rms_mth.aspx?SelectDate=2015-04&reportType=SDRCV&tsvflag=Y");
+		Assert.assertEquals(url, "https://www.imf.org/external/np/fin/data/rms_mth.aspx?SelectDate=2015-04&reportType=SDRCV&tsvflag=Y");
 	}
 }

--- a/moneta-convert/moneta-convert-imf/update_imf.sh
+++ b/moneta-convert/moneta-convert-imf/update_imf.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 printf "\n Downloading the IMF resource. \n"
-wget http://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
+wget https://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
 mv rms_five.aspx?tsvflag=Y src/main/resources/java-money/defaults/IMF/rms_five.xls
 printf "\n Done. \n"

--- a/moneta-core/src/main/asciidoc/userguide.adoc
+++ b/moneta-core/src/main/asciidoc/userguide.adoc
@@ -700,20 +700,20 @@ data feeds and the (re)load/update settings:
 load.ECBCurrentRateProvider.type=SCHEDULED
 load.ECBCurrentRateProvider.period=03:00
 load.ECBCurrentRateProvider.resource=/java-money/defaults/ECB/eurofxref-daily.xml
-load.ECBCurrentRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
+load.ECBCurrentRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 
 load.ECBHistoric90RateProvider.type=SCHEDULED
 load.ECBHistoric90RateProvider.period=03:00
 #load.ECBHistoric90RateProvider.at=12:00
 load.ECBHistoric90RateProvider.resource=/java-money/defaults/ECB/eurofxref-hist-90d.xml
-load.ECBHistoric90RateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
+load.ECBHistoric90RateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
 
 load.ECBHistoricRateProvider.type=SCHEDULED
 load.ECBHistoricRateProvider.period=24:00
 load.ECBHistoricRateProvider.delay=01:00
 load.ECBHistoricRateProvider.at=07:00
 load.ECBHistoricRateProvider.resource=/java-money/defaults/ECB/eurofxref-hist.xml
-load.ECBHistoricRateProvider.urls=http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
+load.ECBHistoricRateProvider.urls=https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml
 
 # IMF Rates
 load.IMFRateProvider.type=SCHEDULED
@@ -721,7 +721,7 @@ load.IMFRateProvider.period=06:00
 #load.IMFRateProvider.delay=12:00
 #load.IMFRateProvider.at=12:00
 load.IMFRateProvider.resource=/java-money/defaults/IMF/rms_five.xls
-load.IMFRateProvider.urls=http://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
+load.IMFRateProvider.urls=https://www.imf.org/external/np/fin/data/rms_five.aspx?tsvflag=Y
 --------------------------------------------
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<testng.version>6.9.12</testng.version>
 		<additionalparam>-Xdoclint:none</additionalparam>
 
-		<!-- OSGO support -->
+		<!-- OSGI support -->
 		<osgi.version>5.0.0</osgi.version>
 		<osgi.compendium.version>${osgi.version}</osgi.compendium.version>
 		<osgi.annotation.version>6.0.0</osgi.annotation.version>
@@ -105,7 +105,7 @@
 		<repository>
 			<id>jcenter</id>
 			<name>JCenter</name>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 		<repository>
 			<snapshots>
@@ -113,7 +113,7 @@
 			</snapshots>
 			<id>bintray-release</id>
 			<name>libs-release</name>
-			<url>http://oss.jfrog.org/artifactory/libs-release</url>
+			<url>https://oss.jfrog.org/artifactory/libs-release</url>
 		</repository>
 		<repository>
 			<snapshots>
@@ -121,7 +121,7 @@
 			</snapshots>
 			<id>bintray-snapshot</id>
 			<name>libs-snapshot</name>
-			<url>http://oss.jfrog.org/artifactory/libs-snapshot</url>
+			<url>https://oss.jfrog.org/artifactory/libs-snapshot</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
To avoid Man-in-the-middle attack when a hacker can change a currency rate we should use HTTPS instead of raw HTTP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/203)
<!-- Reviewable:end -->
