### PR TITLE
Travis-CI: build with OpenJDK instead of Oracle JDK and check build with JDK10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: java
 jdk:
-  - oraclejdk9
-addons:
-  apt:
-    packages:
-      - oracle-java9-installer
+  - openjdk9
+  - openjdk10
 
 after_success:
   - mvn deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml


### PR DESCRIPTION
For JavaMoney it's enough any OpenJDK so we don't need to build with OracleJDK.
Also JDK9 now is outdated and we should use JDK10. But anyway it is better to build with OpenJDK9 too to be 100% sure about compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/204)
<!-- Reviewable:end -->
