### PR TITLE
Add --batch-mode to Maven commands in CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ addons:
       - oracle-java9-installer
 
 after_success:
-  - mvn deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml
-  - mvn jacoco:report coveralls:jacoco -DsourceEncoding=UTF-8
+  - mvn --batch-mode deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml
+  - mvn --batch-mode jacoco:report coveralls:jacoco -DsourceEncoding=UTF-8


### PR DESCRIPTION
--batch-mode is more convenient for CI services since it avoids
unnecessary expansion of the build output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/207)
<!-- Reviewable:end -->
