### PR TITLE
FastMoney.divide uses double

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -350,7 +350,9 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         if (isOne(divisor)) {
             return this;
         }
-        return new FastMoney(Math.round(this.number / divisor.doubleValue()), getCurrency());
+        BigDecimal div = MoneyUtils.getBigDecimal(divisor);
+        BigDecimal res = getBigDecimal().divide(div);
+        return new FastMoney(res, getCurrency(), false);
     }
 
     @Override

--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -318,6 +318,19 @@ public class FastMoneyTest {
     /**
      * Test method for {@link org.javamoney.moneta.FastMoney#divide(java.lang.Number)}.
      */
+    @Test
+    public void testDivideNumber_AvoidsDouble() {
+        BigDecimal baseValue = new BigDecimal("10000000");
+        BigDecimal divisor = new BigDecimal("0.00001");
+  
+        FastMoney m = FastMoney.of(baseValue, "CHF");
+        BigDecimal expectedValue = baseValue.divide(divisor);
+        assertEquals(FastMoney.of(expectedValue, "CHF"), m.divide(divisor));
+    }
+
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#divide(java.lang.Number)}.
+     */
     @Test(expectedExceptions = java.lang.ArithmeticException.class)
     public void testDivideNumber_Overflow() {
         FastMoney m = FastMoney.of(100, "CHF");


### PR DESCRIPTION
FastMoney.divide uses double resulting in imprecise resutls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/216)
<!-- Reviewable:end -->
