### PR TITLE
Compile with -release instead of -source -target

### DIFF
--- a/moneta-convert/moneta-convert-base/pom.xml
+++ b/moneta-convert/moneta-convert-base/pom.xml
@@ -41,15 +41,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <release>9</release>
                 </configuration>
                 <executions>
                     <execution>
                         <id>default-compile</id>
                         <configuration>
-                            <source>9</source>
-                            <target>9</target>
                             <!-- compile everything to ensure module-info contains right entries -->
                             <!-- required when JAVA_HOME is JDK 8 or below -->
                             <jdkToolchain>
@@ -65,8 +62,7 @@
                         </goals>
                         <!-- recompile everything for target VM except the module-info.java -->
                         <configuration>
-                            <source>${maven.compile.sourceLevel}</source>
-                            <target>${maven.compile.targetLevel}</target>
+                            <release>${maven.compiler.release}</release>
                             <excludes>
                                 <exclude>org/javamoney/moneta/convert/module-info.java</exclude>
                             </excludes>

--- a/moneta-convert/moneta-convert-ecb/pom.xml
+++ b/moneta-convert/moneta-convert-ecb/pom.xml
@@ -48,15 +48,12 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>9</source>
-					<target>9</target>
+					<release>9</release>
 				</configuration>
 				<executions>
 					<execution>
 						<id>default-compile</id>
 						<configuration>
-							<source>9</source>
-							<target>9</target>
 							<!-- compile everything to ensure module-info contains right entries -->
 							<!-- required when JAVA_HOME is JDK 8 or below -->
 							<jdkToolchain>
@@ -72,8 +69,7 @@
 						</goals>
 						<!-- recompile everything for target VM except the module-info.java -->
 						<configuration>
-							<source>${maven.compile.sourceLevel}</source>
-							<target>${maven.compile.targetLevel}</target>
+							<release>${maven.compiler.release}</release>
 							<excludes>
 								<exclude>org/javamoney/moneta/convert/ecb/module-info.java</exclude>
 							</excludes>

--- a/moneta-convert/moneta-convert-imf/pom.xml
+++ b/moneta-convert/moneta-convert-imf/pom.xml
@@ -48,15 +48,12 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>9</source>
-					<target>9</target>
+					<release>9</release>
 				</configuration>
 				<executions>
 					<execution>
 						<id>default-compile</id>
 						<configuration>
-							<source>9</source>
-							<target>9</target>
 							<!-- compile everything to ensure module-info contains right entries -->
 							<!-- required when JAVA_HOME is JDK 8 or below -->
 							<jdkToolchain>
@@ -72,8 +69,7 @@
 						</goals>
 						<!-- recompile everything for target VM except the module-info.java -->
 						<configuration>
-							<source>${maven.compile.sourceLevel}</source>
-							<target>${maven.compile.targetLevel}</target>
+							<release>${maven.compiler.release}</release>
 							<excludes>
 								<exclude>org/javamoney/moneta/convert/imf/module-info.java</exclude>
 							</excludes>

--- a/moneta-core/pom.xml
+++ b/moneta-core/pom.xml
@@ -402,8 +402,7 @@
 						</goals>
 						<!-- recompile everything for target VM except the module-info.java -->
 						<configuration>
-							<source>${maven.compile.sourceLevel}</source>
-							<target>${maven.compile.targetLevel}</target>
+							<release>${maven.compiler.release}</release>
 							<excludes>
 								<exclude>org/javamoney/moneta/module-info.java</exclude>
 							</excludes>

--- a/moneta/pom.xml
+++ b/moneta/pom.xml
@@ -358,10 +358,9 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.7.0</version>
+					<version>3.8.0</version>
 					<configuration>
-						<source>${maven.compile.sourceLevel}</source>
-						<target>${maven.compile.targetLevel}</target>
+						<release>${maven.compiler.release}</release>
 						<excludes>
 							<exclude>module-info.java</exclude>
 						</excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,7 @@
 	<properties>
 		<jsr.version>1.0.3</jsr.version>
 		<jdkVersion>1.8</jdkVersion>
-		<maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
-		<maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
+		<maven.compiler.release>8</maven.compiler.release>
 
 		<moduleDir>.</moduleDir>
 		<basedir>.</basedir>


### PR DESCRIPTION
In order to have safe cross compilation and fix #223 and #189 we need
to use -release, see JEP 247 [1]

 [1] http://openjdk.java.net/jeps/247

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/224)
<!-- Reviewable:end -->
