### PR TITLE
Clean up OSGi classes

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/OSGIActivator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/OSGIActivator.java
@@ -36,7 +36,7 @@ public class OSGIActivator implements BundleActivator {
 
     private static final Logger LOG = Logger.getLogger(OSGIActivator.class.getName());
 
-    private OSGIServiceProvider serviceProvider;
+    private volatile OSGIServiceProvider serviceProvider;
 
     @Override
     public void start(BundleContext context) {

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/OSGIServiceComparator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/OSGIServiceComparator.java
@@ -26,14 +26,11 @@ import java.util.Comparator;
 /**
  * Comparator implementation for ordering services loaded based on their increasing priority values.
  */
-@SuppressWarnings("rawtypes")
-class OSGIServiceComparator implements Comparator<ServiceReference> {
+class OSGIServiceComparator implements Comparator<ServiceReference<?>> {
 
     @Override
-    public int compare(ServiceReference o1, ServiceReference o2) {
-        int prio = getPriority(o1) - getPriority(o2);
-        //o1.getClass().getSimpleName().compareTo(o2.getClass().getSimpleName());
-        return Integer.compare(0, prio);
+    public int compare(ServiceReference<?> o1, ServiceReference<?> o2) {
+        return Integer.compare(getPriority(o1), getPriority(o2));
     }
 
     /**


### PR DESCRIPTION
The following commit cleans up the OSGi classes by

- use proper logging instead of printStackTrace
- add proper logging guards
- remove unused imports
- remove confusing TAMAYA from the log
- do not use deprecated Class.newInstance() method
- get rid of raw type warnings by using generics
- use safe publication for OSGIActivator.serviceProvider
- at least log an exception when it is swallowed
- document empty method body (codacy)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/225)
<!-- Reviewable:end -->
