### PR TITLE
BigDecimal.ROUND_HALF_EVEN is deprecated

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
@@ -52,7 +52,7 @@ final class ReciprocalOperator implements MonetaryOperator{
         Objects.requireNonNull(amount, "Amount required.");
         NumberValue num = amount.getNumber();
         BigDecimal one = new BigDecimal("1.0").setScale(num.getScale() < 5 ? 5 : num.getScale(),
-                BigDecimal.ROUND_HALF_EVEN);
+                RoundingMode.HALF_EVEN);
         return amount.getFactory().setNumber(one.divide(num.numberValue(BigDecimal.class), RoundingMode.HALF_EVEN))
                 .create();
     }

--- a/moneta-core/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
@@ -459,7 +459,7 @@ public class RoundedMoneyTest {
     public void testDivideNumber() {
         RoundedMoney m = RoundedMoney.of(100, "CHF");
         assertEquals(RoundedMoney.of(new BigDecimal("100.00").divide(BigDecimal.valueOf(5),
-                        BigDecimal.ROUND_HALF_EVEN), "CHF"),
+                        RoundingMode.HALF_EVEN), "CHF"),
                 m.divide(BigDecimal.valueOf(5)));
     }
 


### PR DESCRIPTION
BigDecimal.ROUND_HALF_EVEN is deprecated since Java 9 and
RoundingMode.HALF_EVEN should be used instead [1]

 [1] https://docs.oracle.com/javase/9/docs/api/java/math/BigDecimal.html#ROUND_HALF_EVEN

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/226)
<!-- Reviewable:end -->
