### PR TITLE
Fix codacy identity comparison warnings

### DIFF
--- a/moneta-core/src/test/java/org/javamoney/moneta/CurrenciesTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/CurrenciesTest.java
@@ -17,6 +17,7 @@ package org.javamoney.moneta;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Currency;
@@ -93,7 +94,7 @@ public class CurrenciesTest {
 		CurrencyUnit cur = Monetary.getCurrency("USD");
 		CurrencyUnit cur2 = Monetary.getCurrency("USD");
 		assertNotNull(cur2);
-		assertTrue(cur == cur2);
+		assertSame(cur, cur2);
 		Currency jdkCurrency = Currency.getInstance("USD");
 		assertEquals(jdkCurrency.getCurrencyCode(), cur.getCurrencyCode());
 		assertEquals(jdkCurrency.getNumericCode(), cur.getNumericCode());

--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -19,6 +19,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -1154,10 +1155,10 @@ public class FastMoneyTest {
     public void testFrom() {
         FastMoney m = FastMoney.of(new BigDecimal("1.2345"), "XXX");
         FastMoney m2 = FastMoney.from(m);
-        assertTrue(m == m2);
+        assertSame(m, m2);
         Money fm = Money.of(new BigDecimal("1.2345"), "XXX");
         m2 = FastMoney.from(fm);
-        assertFalse(m == m2);
+        assertNotSame(m, m2);
         assertEquals(m, m2);
     }
 
@@ -1171,7 +1172,7 @@ public class FastMoneyTest {
         ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()));
         FastMoney m2 = (FastMoney) ois.readObject();
         assertEquals(m, m2);
-        assertTrue(m != m2);
+        assertNotSame(m, m2);
     }
 
     @Test

--- a/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -19,6 +19,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -450,7 +451,7 @@ public class MoneyTest {
                 MonetaryContextBuilder.of(Money.class).setPrecision(128).set(RoundingMode.HALF_EVEN).build();
         MonetaryAmount m2 = m.getFactory().setContext(mc).create();
         assertNotNull(m2);
-        assertTrue(m != m2);
+        assertNotSame(m, m2);
         assertEquals(Money.DEFAULT_MONETARY_CONTEXT, m.getContext());
         assertEquals(mc, m2.getContext());
     }
@@ -1114,7 +1115,7 @@ public class MoneyTest {
     public void testFrom() {
         Money m = Money.of(new BigDecimal("1.2345"), "XXX");
         Money m2 = Money.from(m);
-        assertTrue(m == m2);
+        assertSame(m, m2);
     }
 
     @Test

--- a/moneta-core/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
@@ -19,6 +19,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -1046,10 +1047,10 @@ public class RoundedMoneyTest {
     public void testFrom() {
         RoundedMoney m = RoundedMoney.of(new BigDecimal("1.2345"), "XXX");
         RoundedMoney m2 = RoundedMoney.from(m);
-        assertTrue(m == m2);
+        assertSame(m, m2);
         FastMoney fm = FastMoney.of(new BigDecimal("1.2345"), "XXX");
         m2 = RoundedMoney.from(fm);
-        assertFalse(m == m2);
+        assertNotSame(m, m2);
         assertEquals(m, m2);
     }
 
@@ -1070,7 +1071,7 @@ public class RoundedMoneyTest {
         ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()));
         RoundedMoney m2 = (RoundedMoney) ois.readObject();
         assertEquals(m, m2);
-        assertTrue(m != m2);
+        assertNotSame(m, m2);
     }
 
     // Bad Cases


### PR DESCRIPTION
codacy warns about identity comparisons in unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/227)
<!-- Reviewable:end -->
