### PR TITLE
Fix codacy unused imports warnings

### DIFF
--- a/moneta-convert/moneta-convert-imf/src/test/java/org/javamoney/moneta/convert/imf/MonetaryConversionTest.java
+++ b/moneta-convert/moneta-convert-imf/src/test/java/org/javamoney/moneta/convert/imf/MonetaryConversionTest.java
@@ -16,7 +16,6 @@
 package org.javamoney.moneta.convert.imf;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -31,7 +30,6 @@ import javax.money.convert.ExchangeRateProvider;
 import javax.money.convert.MonetaryConversions;
 
 import org.javamoney.moneta.Money;
-import org.javamoney.moneta.convert.imf.IMFRateProvider;
 import org.testng.annotations.Test;
 
 public class MonetaryConversionTest {

--- a/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -30,14 +30,9 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.util.Locale;
 
 import javax.money.*;
-import javax.money.format.AmountFormatQueryBuilder;
-import javax.money.format.MonetaryAmountFormat;
-import javax.money.format.MonetaryFormats;
 
-import org.javamoney.moneta.format.CurrencyStyle;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryAmountDecimalFormatBuilderTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryAmountDecimalFormatBuilderTest.java
@@ -17,12 +17,10 @@ package org.javamoney.moneta.format;
 
 import org.javamoney.moneta.function.FastMoneyProducer;
 import org.javamoney.moneta.function.MoneyProducer;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
-import javax.money.format.MonetaryAmountFormat;
 import java.util.Locale;
 
 import static org.testng.Assert.assertEquals;


### PR DESCRIPTION
codacy warns about unused imports in unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/228)
<!-- Reviewable:end -->
