### PR TITLE
FastMoney should not use internal rounding

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -135,11 +135,11 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
      * @param currency the currency, not null.
      * @param number   the amount, not null.
      */
-    private FastMoney(Number number, CurrencyUnit currency, boolean allowInternalRounding) {
+    private FastMoney(Number number, CurrencyUnit currency) {
         Objects.requireNonNull(currency, "Currency is required.");
         this.currency = currency;
         Objects.requireNonNull(number, "Number is required.");
-        this.number = getInternalNumber(number, allowInternalRounding);
+        this.number = getInternalNumber(number);
     }
 
     /**
@@ -148,11 +148,11 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
      * @param currency    the currency, not null.
      * @param numberValue the numeric value, not null.
      */
-    private FastMoney(NumberValue numberValue, CurrencyUnit currency, boolean allowInternalRounding) {
+    private FastMoney(NumberValue numberValue, CurrencyUnit currency) {
         Objects.requireNonNull(currency, "Currency is required.");
         this.currency = currency;
         Objects.requireNonNull(numberValue, "Number is required.");
-        this.number = getInternalNumber(numberValue.numberValue(BigDecimal.class), allowInternalRounding);
+        this.number = getInternalNumber(numberValue.numberValue(BigDecimal.class));
     }
 
     /**
@@ -191,9 +191,9 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         return MONETARY_CONTEXT;
     }
 
-    private long getInternalNumber(Number number, boolean allowInternalRounding) {
+    private long getInternalNumber(Number number) {
         BigDecimal bd = MoneyUtils.getBigDecimal(number);
-        if (!allowInternalRounding && bd.scale() > SCALE) {
+        if (bd.scale() > SCALE) {
             throw new ArithmeticException(number + " can not be represented by this class, scale > " + SCALE);
         }
         if (bd.compareTo(MIN_BD) < 0) {
@@ -213,7 +213,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
      * @return A new instance of {@link FastMoney}.
      */
     public static FastMoney of(NumberValue numberBinding, CurrencyUnit currency) {
-        return new FastMoney(numberBinding, currency, false);
+        return new FastMoney(numberBinding, currency);
     }
 
     /**
@@ -224,7 +224,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
      * @return A new instance of {@link FastMoney}.
      */
     public static FastMoney of(Number number, CurrencyUnit currency) {
-        return new FastMoney(number, currency, false);
+        return new FastMoney(number, currency);
     }
 
     /**
@@ -326,7 +326,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         if (amount.isZero()) {
             return this;
         }
-        return new FastMoney(Math.addExact(this.number, getInternalNumber(amount.getNumber(), false)), getCurrency());
+        return new FastMoney(Math.addExact(this.number, getInternalNumber(amount.getNumber())), getCurrency());
     }
 
     private void checkAmountParameter(MonetaryAmount amount) {
@@ -352,7 +352,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         }
         BigDecimal div = MoneyUtils.getBigDecimal(divisor);
         BigDecimal res = getBigDecimal().divide(div);
-        return new FastMoney(res, getCurrency(), false);
+        return new FastMoney(res, getCurrency());
     }
 
     @Override
@@ -364,7 +364,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         checkNumber(divisor);
         BigDecimal div = MoneyUtils.getBigDecimal(divisor);
         BigDecimal[] res = getBigDecimal().divideAndRemainder(div);
-        return new FastMoney[]{new FastMoney(res[0], getCurrency(), false), new FastMoney(res[1], getCurrency(), false)};
+        return new FastMoney[]{new FastMoney(res[0], getCurrency()), new FastMoney(res[1], getCurrency())};
     }
 
     @Override
@@ -377,7 +377,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
             return this;
         }
         BigDecimal div = MoneyUtils.getBigDecimal(divisor);
-        return new FastMoney(getBigDecimal().divideToIntegralValue(div), getCurrency(), false);
+        return new FastMoney(getBigDecimal().divideToIntegralValue(div), getCurrency());
     }
 
     @Override
@@ -387,7 +387,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         if (isOne(multiplicand)) {
             return this;
         }
-        return new FastMoney(Math.multiplyExact(this.number, getInternalNumber(multiplicand, false)) / 100000L,
+        return new FastMoney(Math.multiplyExact(this.number, getInternalNumber(multiplicand)) / 100000L,
                 getCurrency());
     }
 
@@ -407,14 +407,14 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         if (subtrahend.isZero()) {
             return this;
         }
-        return new FastMoney(Math.subtractExact(this.number, getInternalNumber(subtrahend.getNumber(), false)),
+        return new FastMoney(Math.subtractExact(this.number, getInternalNumber(subtrahend.getNumber())),
                 getCurrency());
     }
 
     @Override
     public FastMoney remainder(Number divisor) {
         checkNumber(divisor);
-        return new FastMoney(this.number % getInternalNumber(divisor, false), getCurrency());
+        return new FastMoney(this.number % getInternalNumber(divisor), getCurrency());
     }
 
     private boolean isOne(Number number) {
@@ -430,7 +430,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
 
     @Override
     public FastMoney scaleByPowerOfTen(int power) {
-        return new FastMoney(getNumber().numberValue(BigDecimal.class).scaleByPowerOfTen(power), getCurrency(), false);
+        return new FastMoney(getNumber().numberValue(BigDecimal.class).scaleByPowerOfTen(power), getCurrency());
     }
 
     @Override
@@ -531,7 +531,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
     public boolean hasSameNumberAs(Number number) {
         checkNumber(number);
         try {
-            return this.number == getInternalNumber(number, false);
+            return this.number == getInternalNumber(number);
         } catch (ArithmeticException e) {
             return false;
         }
@@ -617,7 +617,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         if (FastMoney.class.isInstance(amount)) {
             return FastMoney.class.cast(amount);
         }
-        return new FastMoney(amount.getNumber(), amount.getCurrency(), false);
+        return new FastMoney(amount.getNumber(), amount.getCurrency());
     }
 
     /**

--- a/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -364,7 +364,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         checkNumber(divisor);
         BigDecimal div = MoneyUtils.getBigDecimal(divisor);
         BigDecimal[] res = getBigDecimal().divideAndRemainder(div);
-        return new FastMoney[]{new FastMoney(res[0], getCurrency(), true), new FastMoney(res[1], getCurrency(), true)};
+        return new FastMoney[]{new FastMoney(res[0], getCurrency(), false), new FastMoney(res[1], getCurrency(), false)};
     }
 
     @Override
@@ -430,7 +430,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
 
     @Override
     public FastMoney scaleByPowerOfTen(int power) {
-        return new FastMoney(getNumber().numberValue(BigDecimal.class).scaleByPowerOfTen(power), getCurrency(), true);
+        return new FastMoney(getNumber().numberValue(BigDecimal.class).scaleByPowerOfTen(power), getCurrency(), false);
     }
 
     @Override

--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -19,6 +19,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -94,6 +95,14 @@ public class FastMoneyTest {
         FastMoney[] divideAndRemainder = money1.divideAndRemainder(new BigDecimal("0.50001"));
         assertEquals(divideAndRemainder[0].getNumber().numberValue(BigDecimal.class), new BigDecimal("1"));
         assertEquals(divideAndRemainder[1].getNumber().numberValue(BigDecimal.class), new BigDecimal("0.49999"));
+    }
+
+    @Test
+    public void testDivideAndRemainderArithmeticException() {
+      BigDecimal original = BigDecimal.ONE;
+      FastMoney money = FastMoney.of(original, "EUR");
+      BigDecimal divisor = new BigDecimal("0.333333");
+      assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(divisor));
     }
 
     @Test
@@ -715,6 +724,16 @@ public class FastMoneyTest {
                 );
             }
         }
+    }
+    
+
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#scaleByPowerOfTen(int)} .
+     */
+    @Test
+    public void testScaleByPowerOfTenArithmeticException() {
+        FastMoney money = FastMoney.of(BigDecimal.valueOf(16, 5), "CHF");
+        assertThrows(ArithmeticException.class, () -> money.scaleByPowerOfTen(-1));
     }
 
     /**


### PR DESCRIPTION
FastMoney currently uses internal rounding for `scaleByPowerOfTen(int)`
and `divideAndRemainder(Number)`. However for both methods the API
specify [1] [2] that.

> throws ArithmeticException - ... or if the result exceeds the numeric
> capabilities of this implementation class ...

Due to the use of internal rounding the following properties do not hold
true

    assertEquals(money, money.scaleByPowerOfTen(-1).scaleByPowerOfTen(1));

    quotient, remainder = money.divideAndRemainder(divisor);
    assertEquals(money, quotient * divisor + remainder);

Removing internal rounding does not break any existing tests.

This PR is split into two commits, the first removes internal rounding
from scaleByPowerOfTen and divideAndRemainder. The second removes
internal rounding as at that point it is always false.

 [1] https://javamoney.github.io/apidocs/javax/money/MonetaryAmount.html#scaleByPowerOfTen-int-
 [2] https://javamoney.github.io/apidocs/javax/money/MonetaryAmount.html#divideAndRemainder-java.lang.Number-

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/231)
<!-- Reviewable:end -->
