### PR TITLE
Avoid intermediate object when creating BigDecimal

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -647,7 +647,7 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
             .of(ToStringMonetaryAmountFormatStyle.FAST_MONEY);
 
     private BigDecimal getBigDecimal() {
-        return BigDecimal.valueOf(this.number).movePointLeft(SCALE);
+        return BigDecimal.valueOf(this.number, SCALE);
     }
 
     @Override

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/DefaultCashRounding.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/DefaultCashRounding.java
@@ -130,7 +130,7 @@ final class DefaultCashRounding implements MonetaryRounding, Serializable {
             }
         }
         return amount.getFactory().setCurrency(amount.getCurrency())
-                .setNumber(BigDecimal.valueOf(minors).movePointLeft(scale)).create();
+                .setNumber(BigDecimal.valueOf(minors, scale)).create();
     }
 
     @Override


### PR DESCRIPTION
Currently in some places a BigDecimal is created from an unscaled value
and a scale using an intermediate BigDecimal. This creates unnecessary
object churn. Such a BigDecimal can be created directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/233)
<!-- Reviewable:end -->
