### PR TITLE
travis build also on jdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - openjdk8
   - openjdk9
   - openjdk10
 


### PR DESCRIPTION
I've tried to build the lib on jdk8 and it failed... So I wanted to ask... How do you ensure the lib is compatible with java 8 when you're not also building it on java 8? 

Or is java 8 no longer supported? 

----

<details>
 <summary>build log with java-8-oracle</summary>

```
[INFO] Scanning for projects...
[WARNING] The project org.javamoney:moneta-parent:pom:1.4-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[WARNING] The project org.javamoney.moneta:moneta-core:jar:1.4-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[WARNING] The project org.javamoney:moneta:pom:1.4-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Moneta Parent                                                      [pom]
[INFO] Moneta Core                                                        [jar]
[INFO] Moneta Currency Conversion (Parent)                                [pom]
[INFO] Moneta Currency Conversion                                         [jar]
[INFO] Moneta Currency Conversion - ECB Provider                          [jar]
[INFO] Moneta Currency Conversion - IMF Provider                          [jar]
[INFO] Moneta (JSR 354 RI)                                                [pom]
[INFO] 
[INFO] --------------------< org.javamoney:moneta-parent >---------------------
[INFO] Building Moneta Parent 1.4-SNAPSHOT                                [1/7]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ moneta-parent ---
[INFO] 
[INFO] --- maven-source-plugin:2.2.1:jar-no-fork (attach-sources) @ moneta-parent ---
[INFO] 
[INFO] --- maven-javadoc-plugin:2.9:jar (attach-javadocs) @ moneta-parent ---
[INFO] Not executing Javadoc as the project is not a Java classpath-capable package
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ moneta-parent ---
[INFO] Installing /home/fprochazka/devel/libs/JavaMoney/jsr354-ri/pom.xml to /home/fprochazka/.m2/repository/org/javamoney/moneta-parent/1.4-SNAPSHOT/moneta-parent-1.4-SNAPSHOT.pom
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default) @ moneta-parent ---
[INFO] Installing /home/fprochazka/devel/libs/JavaMoney/jsr354-ri/pom.xml to /home/fprochazka/.m2/repository/org/javamoney/moneta-parent/1.4-SNAPSHOT/moneta-parent-1.4-SNAPSHOT.pom
[INFO] 
[INFO] ------------------< org.javamoney.moneta:moneta-core >------------------
[INFO] Building Moneta Core 1.4-SNAPSHOT                                  [2/7]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ moneta-core ---
[INFO] Deleting /home/fprochazka/devel/libs/JavaMoney/jsr354-ri/moneta-core/target
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ moneta-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 10 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ moneta-core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 123 source files to /home/fprochazka/devel/libs/JavaMoney/jsr354-ri/moneta-core/target/classes
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Moneta Parent 1.4-SNAPSHOT ......................... SUCCESS [  0.554 s]
[INFO] Moneta Core ........................................ FAILURE [  0.281 s]
[INFO] Moneta Currency Conversion (Parent) ................ SKIPPED
[INFO] Moneta Currency Conversion ......................... SKIPPED
[INFO] Moneta Currency Conversion - ECB Provider .......... SKIPPED
[INFO] Moneta Currency Conversion - IMF Provider .......... SKIPPED
[INFO] Moneta (JSR 354 RI) 1.4-SNAPSHOT ................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.384 s
[INFO] Finished at: 2018-10-06T21:52:31+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project moneta-core: Fatal error compiling: invalid flag: --module-path -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :moneta-core

Process finished with exit code 1

```

</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/235)
<!-- Reviewable:end -->
