### PR TITLE
CompoundRateProvider no longer hides errors

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/CompoundRateProvider.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/CompoundRateProvider.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This class implements a {@link ExchangeRateProvider} that delegates calls to
@@ -113,9 +111,9 @@ public class CompoundRateProvider extends AbstractRateProvider {
                     }
                 }
             } catch (Exception e) {
-                Logger.getLogger(getClass().getName()).log(Level.WARNING,
-                        "Rate Provider did not return data though at check before data was flagged as available," +
-                                " provider=" + prov.getContext().getProviderName() + ", query=" + conversionQuery);
+                throw new CurrencyConversionException(conversionQuery.getBaseCurrency(), conversionQuery.getCurrency(), null,
+                    "Rate Provider did not return data though at check before data was flagged as available," +
+                        " provider=" + prov.getContext().getProviderName() + ", query=" + conversionQuery, e);
             }
         }
         throw new CurrencyConversionException(conversionQuery.getBaseCurrency(), conversionQuery.getCurrency(), null,


### PR DESCRIPTION
I think hiding errors in the `CompoundRateProvider` is very bad. I also think catching generic `Exception` is very bad (since you can hide even NPE and similar errors that should never be handled), but at least now it doesn't hide them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/236)
<!-- Reviewable:end -->
