### PR TITLE
introduce DataStreamFactory to fix InputStream reuse

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DataStreamFactory.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DataStreamFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012, 2015, Credit Suisse (Anatole Tresch), Werner Keil and others by the @author tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.javamoney.moneta.internal.loader;
+
+import java.io.InputStream;
+
+public interface DataStreamFactory
+{
+
+    InputStream getDataStream();
+
+}

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderListener.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderListener.java
@@ -15,7 +15,6 @@
  */
 package org.javamoney.moneta.internal.loader;
 
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -61,15 +60,15 @@ class DefaultLoaderListener {
      * Trigger the listeners registered for the given dataId.
      *
      * @param dataId the data id, not null.
-     * @param is     the InputStream, containing the latest data.
+     * @param dataStreamFactory factory of the InputStream with the latest data.
      */
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-    public void trigger(String dataId, InputStream is) {
+    public void trigger(String dataId, DataStreamFactory dataStreamFactory) {
         List<LoaderListener> listeners = getListeners("");
         synchronized (listeners) {
             for (LoaderListener ll : listeners) {
                 try {
-                    ll.newDataLoaded(dataId, is);
+                    ll.newDataLoaded(dataId, dataStreamFactory.getDataStream());
                 } catch (Exception e) {
                     LOG.log(Level.SEVERE, "Error calling LoadListener: " + ll, e);
                 }
@@ -80,7 +79,7 @@ class DefaultLoaderListener {
             synchronized (listeners) {
                 for (LoaderListener ll : listeners) {
                     try {
-                        ll.newDataLoaded(dataId, is);
+                        ll.newDataLoaded(dataId, dataStreamFactory.getDataStream());
                     } catch (Exception e) {
                         throw new IllegalArgumentException("Failed to load new data: " + ll, e);
                     }

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderService.java
@@ -280,7 +280,7 @@ public class DefaultLoaderService implements LoaderService {
         LoadableResource load = Optional.ofNullable(this.resources.get(resourceId))
                 .orElseThrow(() -> new IllegalArgumentException("No such resource: " + resourceId));
         if (load.resetToFallback()) {
-        	listener.trigger(resourceId, load.getDataStream());
+        	listener.trigger(resourceId, load);
         }
     }
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLoaderService.java
@@ -38,7 +38,7 @@ public class LoadDataLoaderService {
 			try {
 				if (load.load()) {
 					LOG.log(Level.INFO, "Read data from: " + load.getRemoteResources());
-					listener.trigger(resourceId, load.getDataStream());
+					listener.trigger(resourceId, load);
 					LOG.log(Level.INFO, "New data successfully loaded from: " + load.getRemoteResources());
 					return true;
 				}
@@ -49,7 +49,7 @@ public class LoadDataLoaderService {
 			try {
 				if (load.loadFallback()) {
 					LOG.log(Level.WARNING, "Read fallback data from: " + load.getFallbackResource());
-					listener.trigger(resourceId, load.getDataStream());
+					listener.trigger(resourceId, load);
 					LOG.log(Level.WARNING, "Loaded fallback data from: " + load.getFallbackResource());
 					return true;
 				}

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLocalLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLocalLoaderService.java
@@ -41,7 +41,7 @@ class LoadDataLocalLoaderService {
 	        if (Objects.nonNull(load)) {
 	            try {
 	                if (load.loadFallback()) {
-	                	listener.trigger(resourceId, load.getDataStream());
+	                	listener.trigger(resourceId, load);
 	                    return true;
 	                }
 	            } catch (Exception e) {

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadRemoteDataLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadRemoteDataLoaderService.java
@@ -37,9 +37,9 @@ class LoadRemoteDataLoaderService {
 		if (Objects.nonNull(load)) {
 			try {
 				load.readCache();
-				listener.trigger(resourceId, load.getDataStream());
+				listener.trigger(resourceId, load);
 				load.loadRemote();
-				listener.trigger(resourceId, load.getDataStream());
+				listener.trigger(resourceId, load);
 				LOG.info("The exchange rate with resourceId " + resourceId + " was started remotely");
 				return true;
 			} catch (Exception e) {

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadableResource.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadableResource.java
@@ -39,7 +39,7 @@ import org.javamoney.moneta.spi.LoaderService;
  * To create this instance use: {@link LoadableResourceBuilder}
  * @author Anatole Tresch
  */
-public class LoadableResource {
+public class LoadableResource implements DataStreamFactory {
 
     /**
      * The logger used.

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/ScheduledDataLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/ScheduledDataLoaderService.java
@@ -44,7 +44,7 @@ class ScheduledDataLoaderService {
 	            public void run() {
 	                try {
 	                    if (load.load()) {
-	                        listener.trigger(load.getResourceId(), load.getDataStream());
+	                        listener.trigger(load.getResourceId(), load);
 	                    }
 	                } catch (Exception e) {
 	                    LOG.log(Level.SEVERE, "Failed to update remote resource: " + load.getResourceId(), e);


### PR DESCRIPTION
## The problem

I've implemented my own consumer for `eurofxref-hist.xml` but there is no reason the have the file two times or have it downloaded two times, when it's the same resource. This library gives the impression that reusing resource for two exchange rate providers is completely fine so I went with it. Turns out, when two "listeners" both receive the same InputStream and they both try to read it, only the first one gets the data and for the second one the InputStream looks empty.

## Solution

For every listener, there has to be a new fresh `InputStream`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/238)
<!-- Reviewable:end -->
