### PR TITLE
TimerTask is not reusable

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DataStreamFactory.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DataStreamFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012, 2015, Credit Suisse (Anatole Tresch), Werner Keil and others by the @author tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.javamoney.moneta.internal.loader;
+
+import java.io.InputStream;
+
+public interface DataStreamFactory
+{
+
+    InputStream getDataStream();
+
+}

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderListener.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderListener.java
@@ -15,7 +15,6 @@
  */
 package org.javamoney.moneta.internal.loader;
 
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -61,15 +60,15 @@ class DefaultLoaderListener {
      * Trigger the listeners registered for the given dataId.
      *
      * @param dataId the data id, not null.
-     * @param is     the InputStream, containing the latest data.
+     * @param dataStreamFactory factory of the InputStream with the latest data.
      */
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-    public void trigger(String dataId, InputStream is) {
+    public void trigger(String dataId, DataStreamFactory dataStreamFactory) {
         List<LoaderListener> listeners = getListeners("");
         synchronized (listeners) {
             for (LoaderListener ll : listeners) {
                 try {
-                    ll.newDataLoaded(dataId, is);
+                    ll.newDataLoaded(dataId, dataStreamFactory.getDataStream());
                 } catch (Exception e) {
                     LOG.log(Level.SEVERE, "Error calling LoadListener: " + ll, e);
                 }
@@ -80,7 +79,7 @@ class DefaultLoaderListener {
             synchronized (listeners) {
                 for (LoaderListener ll : listeners) {
                     try {
-                        ll.newDataLoaded(dataId, is);
+                        ll.newDataLoaded(dataId, dataStreamFactory.getDataStream());
                     } catch (Exception e) {
                         throw new IllegalArgumentException("Failed to load new data: " + ll, e);
                     }

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DefaultLoaderService.java
@@ -280,7 +280,7 @@ public class DefaultLoaderService implements LoaderService {
         LoadableResource load = Optional.ofNullable(this.resources.get(resourceId))
                 .orElseThrow(() -> new IllegalArgumentException("No such resource: " + resourceId));
         if (load.resetToFallback()) {
-        	listener.trigger(resourceId, load.getDataStream());
+        	listener.trigger(resourceId, load);
         }
     }
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLoaderService.java
@@ -38,7 +38,7 @@ public class LoadDataLoaderService {
 			try {
 				if (load.load()) {
 					LOG.log(Level.INFO, "Read data from: " + load.getRemoteResources());
-					listener.trigger(resourceId, load.getDataStream());
+					listener.trigger(resourceId, load);
 					LOG.log(Level.INFO, "New data successfully loaded from: " + load.getRemoteResources());
 					return true;
 				}
@@ -49,7 +49,7 @@ public class LoadDataLoaderService {
 			try {
 				if (load.loadFallback()) {
 					LOG.log(Level.WARNING, "Read fallback data from: " + load.getFallbackResource());
-					listener.trigger(resourceId, load.getDataStream());
+					listener.trigger(resourceId, load);
 					LOG.log(Level.WARNING, "Loaded fallback data from: " + load.getFallbackResource());
 					return true;
 				}

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLocalLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadDataLocalLoaderService.java
@@ -41,7 +41,7 @@ class LoadDataLocalLoaderService {
 	        if (Objects.nonNull(load)) {
 	            try {
 	                if (load.loadFallback()) {
-	                	listener.trigger(resourceId, load.getDataStream());
+	                	listener.trigger(resourceId, load);
 	                    return true;
 	                }
 	            } catch (Exception e) {

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadRemoteDataLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadRemoteDataLoaderService.java
@@ -37,9 +37,9 @@ class LoadRemoteDataLoaderService {
 		if (Objects.nonNull(load)) {
 			try {
 				load.readCache();
-				listener.trigger(resourceId, load.getDataStream());
+				listener.trigger(resourceId, load);
 				load.loadRemote();
-				listener.trigger(resourceId, load.getDataStream());
+				listener.trigger(resourceId, load);
 				LOG.info("The exchange rate with resourceId " + resourceId + " was started remotely");
 				return true;
 			} catch (Exception e) {

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadableResource.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/LoadableResource.java
@@ -39,7 +39,7 @@ import org.javamoney.moneta.spi.LoaderService;
  * To create this instance use: {@link LoadableResourceBuilder}
  * @author Anatole Tresch
  */
-public class LoadableResource {
+public class LoadableResource implements DataStreamFactory {
 
     /**
      * The logger used.

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/ScheduledDataLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/ScheduledDataLoaderService.java
@@ -44,7 +44,7 @@ class ScheduledDataLoaderService {
 	            public void run() {
 	                try {
 	                    if (load.load()) {
-	                        listener.trigger(load.getResourceId(), load.getDataStream());
+	                        listener.trigger(load.getResourceId(), load);
 	                    }
 	                } catch (Exception e) {
 	                    LOG.log(Level.SEVERE, "Failed to update remote resource: " + load.getResourceId(), e);

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/ScheduledDataLoaderService.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/ScheduledDataLoaderService.java
@@ -27,121 +27,121 @@ import java.util.logging.Logger;
 
 class ScheduledDataLoaderService {
 
-	private static final Logger LOG = Logger.getLogger(ScheduledDataLoaderService.class.getName());
+    private static final Logger LOG = Logger.getLogger(ScheduledDataLoaderService.class.getName());
 
-	private final Timer timer;
-	private final DefaultLoaderListener listener;
+    private final Timer timer;
+    private final DefaultLoaderListener listener;
 
-	ScheduledDataLoaderService(Timer timer, DefaultLoaderListener listener) {
-		this.timer = timer;
-		this.listener = listener;
-	}
+    ScheduledDataLoaderService(Timer timer, DefaultLoaderListener listener) {
+        this.timer = timer;
+        this.listener = listener;
+    }
 
-	public void execute(final LoadableResource load) {
-	        Objects.requireNonNull(load);
-	        TimerTask task = new TimerTask() {
-	            @Override
-	            public void run() {
-	                try {
-	                    if (load.load()) {
-	                        listener.trigger(load.getResourceId(), load);
-	                    }
-	                } catch (Exception e) {
-	                    LOG.log(Level.SEVERE, "Failed to update remote resource: " + load.getResourceId(), e);
-	                }
-	            }
-	        };
-	        Map<String, String> props = load.getProperties();
-	        if (Objects.nonNull(props)) {
-	            String value = props.get("period");
-	            long periodMS = parseDuration(value);
-	            value = props.get("delay");
-	            long delayMS = parseDuration(value);
-	            if (periodMS > 0) {
-	                timer.scheduleAtFixedRate(task, delayMS, periodMS);
-	            } else {
-	                value = props.get("at");
-	                if (Objects.nonNull(value)) {
-	                    List<GregorianCalendar> dates = parseDates(value);
-	                    dates.forEach(date -> timer.schedule(task, date.getTime(), 3_600_000 * 24 /* daily */));
-	                }
-	            }
-	        }
-	    }
+    public void execute(final LoadableResource load) {
+        Objects.requireNonNull(load);
+        TimerTask task = new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    if (load.load()) {
+                        listener.trigger(load.getResourceId(), load);
+                    }
+                } catch (Exception e) {
+                    LOG.log(Level.SEVERE, "Failed to update remote resource: " + load.getResourceId(), e);
+                }
+            }
+        };
+        Map<String, String> props = load.getProperties();
+        if (Objects.nonNull(props)) {
+            String value = props.get("period");
+            long periodMS = parseDuration(value);
+            value = props.get("delay");
+            long delayMS = parseDuration(value);
+            if (periodMS > 0) {
+                timer.scheduleAtFixedRate(task, delayMS, periodMS);
+            } else {
+                value = props.get("at");
+                if (Objects.nonNull(value)) {
+                    List<GregorianCalendar> dates = parseDates(value);
+                    dates.forEach(date -> timer.schedule(task, date.getTime(), 3_600_000 * 24 /* daily */));
+                }
+            }
+        }
+    }
 
-	 /**
-	     * Parse the dates of type HH:mm:ss:nnn, whereas minutes and smaller are
-	     * optional.
-	     *
-	     * @param value the input text
-	     * @return the parsed
-	     */
-	    private List<GregorianCalendar> parseDates(String value) {
-	        String[] parts = value.split(",");
-	        List<GregorianCalendar> result = new ArrayList<>();
-	        for (String part : parts) {
-	            if (part.isEmpty()) {
-	                continue;
-	            }
-	            String[] subparts = part.split(":");
-	            GregorianCalendar cal = new GregorianCalendar();
-	            for (int i = 0; i < subparts.length; i++) {
-	                switch (i) {
-	                    case 0:
-	                        cal.set(GregorianCalendar.HOUR_OF_DAY, Integer.parseInt(subparts[i]));
-	                        break;
-	                    case 1:
-	                        cal.set(GregorianCalendar.MINUTE, Integer.parseInt(subparts[i]));
-	                        break;
-	                    case 2:
-	                        cal.set(GregorianCalendar.SECOND, Integer.parseInt(subparts[i]));
-	                        break;
-	                    case 3:
-	                        cal.set(GregorianCalendar.MILLISECOND, Integer.parseInt(subparts[i]));
-	                        break;
-	                }
-	            }
-	            result.add(cal);
-	        }
-	        return result;
-	    }
+    /**
+     * Parse the dates of type HH:mm:ss:nnn, whereas minutes and smaller are
+     * optional.
+     *
+     * @param value the input text
+     * @return the parsed
+     */
+    private List<GregorianCalendar> parseDates(String value) {
+        String[] parts = value.split(",");
+        List<GregorianCalendar> result = new ArrayList<>();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            String[] subparts = part.split(":");
+            GregorianCalendar cal = new GregorianCalendar();
+            for (int i = 0; i < subparts.length; i++) {
+                switch (i) {
+                    case 0:
+                        cal.set(GregorianCalendar.HOUR_OF_DAY, Integer.parseInt(subparts[i]));
+                        break;
+                    case 1:
+                        cal.set(GregorianCalendar.MINUTE, Integer.parseInt(subparts[i]));
+                        break;
+                    case 2:
+                        cal.set(GregorianCalendar.SECOND, Integer.parseInt(subparts[i]));
+                        break;
+                    case 3:
+                        cal.set(GregorianCalendar.MILLISECOND, Integer.parseInt(subparts[i]));
+                        break;
+                }
+            }
+            result.add(cal);
+        }
+        return result;
+    }
 
-	    /**
-	     * Parse a duration of the form HH:mm:ss:nnn, whereas only hours are non
-	     * optional.
-	     *
-	     * @param value the input value
-	     * @return the duration in ms.
-	     */
-	     private long parseDuration(String value) {
-	        long periodMS = 0L;
-	        if (Objects.nonNull(value)) {
-	            String[] parts = value.split(":");
-	            for (int i = 0; i < parts.length; i++) {
-	                switch (i) {
-	                    case 0: // hours
-	                        periodMS += (Integer.parseInt(parts[i])) * 3600000L;
-	                        break;
-	                    case 1: // minutes
-	                        periodMS += (Integer.parseInt(parts[i])) * 60000L;
-	                        break;
-	                    case 2: // seconds
-	                        periodMS += (Integer.parseInt(parts[i])) * 1000L;
-	                        break;
-	                    case 3: // ms
-	                        periodMS += (Integer.parseInt(parts[i]));
-	                        break;
-	                    default:
-	                        break;
-	                }
-	            }
-	        }
-	        return periodMS;
-	    }
+    /**
+     * Parse a duration of the form HH:mm:ss:nnn, whereas only hours are non
+     * optional.
+     *
+     * @param value the input value
+     * @return the duration in ms.
+     */
+     private long parseDuration(String value) {
+        long periodMS = 0L;
+        if (Objects.nonNull(value)) {
+            String[] parts = value.split(":");
+            for (int i = 0; i < parts.length; i++) {
+                switch (i) {
+                    case 0: // hours
+                        periodMS += (Integer.parseInt(parts[i])) * 3600000L;
+                        break;
+                    case 1: // minutes
+                        periodMS += (Integer.parseInt(parts[i])) * 60000L;
+                        break;
+                    case 2: // seconds
+                        periodMS += (Integer.parseInt(parts[i])) * 1000L;
+                        break;
+                    case 3: // ms
+                        periodMS += (Integer.parseInt(parts[i]));
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        return periodMS;
+    }
 
-	@Override
-	public String toString() {
-		return ScheduledDataLoaderService.class.getName() + '{' + " timer: "
-				+ timer + '}';
-	}
+    @Override
+    public String toString() {
+        return ScheduledDataLoaderService.class.getName() + '{' + " timer: "
+                + timer + '}';
+    }
 }


### PR DESCRIPTION
This PR depends on https://github.com/JavaMoney/jsr354-ri/pull/238 - if you merge https://github.com/JavaMoney/jsr354-ri/pull/238 first, this should not create any conflicts.

------

I've looked at the implementation of `ScheduledDataLoaderService#parseDates` and came to the conclusion, that it supports the following format: `03:00,06:00,09:00` which **should** create three times at 3am, 6am and 9am respectively.

But instead it throws an exception. It's because the same instance of timer is used for all the times that are extracted from the config.

<details>
<summary>exception trace when task is reused</summary>

```
00:23:44.361 [restartedMain  ] ERROR o.j.moneta.internal.loader.LoaderConfigurator:	Failed to initialize/register resource: CNBQuarterlyAverageRateProvider-2018 
java.lang.IllegalStateException: Task already scheduled or cancelled
	at java.util.Timer.sched(Timer.java:401)
	at java.util.Timer.schedule(Timer.java:287)
	at org.javamoney.moneta.internal.loader.ScheduledDataLoaderService.lambda$execute$0(ScheduledDataLoaderService.java:66)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.javamoney.moneta.internal.loader.ScheduledDataLoaderService.execute(ScheduledDataLoaderService.java:66)
	at org.javamoney.moneta.internal.loader.DefaultLoaderServiceFacade.scheduledData(DefaultLoaderServiceFacade.java:39)
	at org.javamoney.moneta.internal.loader.DefaultLoaderService.registerData(DefaultLoaderService.java:175)
	at org.javamoney.moneta.internal.loader.LoaderConfigurator.initResource(LoaderConfigurator.java:92)
	at org.javamoney.moneta.internal.loader.LoaderConfigurator.load(LoaderConfigurator.java:59)
	at org.javamoney.moneta.internal.loader.DefaultLoaderService.initialize(DefaultLoaderService.java:101)
	at org.javamoney.moneta.internal.loader.DefaultLoaderService.<init>(DefaultLoaderService.java:85)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:170)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:87)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1221)
	.....
```

</details>

-----

Also, I've fixed some inconsistent whitespace in the relevant file. If that's a problem, I can remove the commit.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/239)
<!-- Reviewable:end -->
