### PR TITLE
Small microoptimization

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
@@ -29,15 +29,13 @@ import javax.money.NumberValue;
  *
  * @author Anatole Tresch
  */
-final class ReciprocalOperator implements MonetaryOperator{
-
+final class ReciprocalOperator implements MonetaryOperator {
 
     /**
      * Access the shared instance of {@link ReciprocalOperator} for use.
      */
     ReciprocalOperator(){
     }
-
 
     /**
      * Gets the amount as reciprocal / multiplicative inversed value (1/n).
@@ -48,10 +46,10 @@ final class ReciprocalOperator implements MonetaryOperator{
      * @throws ArithmeticException if the arithmetic operation failed
      */
     @Override
-    public MonetaryAmount apply(MonetaryAmount amount){
+    public MonetaryAmount apply(MonetaryAmount amount) {
         Objects.requireNonNull(amount, "Amount required.");
         NumberValue num = amount.getNumber();
-        BigDecimal one = new BigDecimal("1.0").setScale(num.getScale() < 5 ? 5 : num.getScale(),
+        BigDecimal one = BigDecimal.ONE.setScale(num.getScale() < 5 ? 5 : num.getScale(),
                 RoundingMode.HALF_EVEN);
         return amount.getFactory().setNumber(one.divide(num.numberValue(BigDecimal.class), RoundingMode.HALF_EVEN))
                 .create();

--- a/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
@@ -16,12 +16,14 @@
 package org.javamoney.moneta.function;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.Objects;
 
 import javax.money.MonetaryAmount;
 import javax.money.MonetaryOperator;
 import javax.money.NumberValue;
+
+import static java.math.BigDecimal.ONE;
+import static java.math.RoundingMode.HALF_EVEN;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class allows to extract the reciprocal value (multiplicative inversion)
@@ -47,12 +49,10 @@ final class ReciprocalOperator implements MonetaryOperator {
      */
     @Override
     public MonetaryAmount apply(MonetaryAmount amount) {
-        Objects.requireNonNull(amount, "Amount required.");
+        requireNonNull(amount, "Amount required.");
         NumberValue num = amount.getNumber();
-        BigDecimal one = BigDecimal.ONE.setScale(num.getScale() < 5 ? 5 : num.getScale(),
-                RoundingMode.HALF_EVEN);
-        return amount.getFactory().setNumber(one.divide(num.numberValue(BigDecimal.class), RoundingMode.HALF_EVEN))
-                .create();
+        BigDecimal one = ONE.setScale(num.getScale() < 5 ? 5 : num.getScale(), HALF_EVEN);
+        return amount.getFactory().setNumber(one.divide(num.numberValue(BigDecimal.class), HALF_EVEN)).create();
     }
 
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/function/ReciprocalOperatorTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/function/ReciprocalOperatorTest.java
@@ -16,7 +16,6 @@
 package org.javamoney.moneta.function;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
@@ -43,9 +42,7 @@ public class ReciprocalOperatorTest {
 		MonetaryAmount result = operator.apply(money);
 		assertEquals(result.getCurrency(), currency);
 		assertEquals(result.getNumber().doubleValue(), 0.5);
-
 	}
-
 
 	@Test
 	public void shouldReturnNegativeValue() {
@@ -54,12 +51,10 @@ public class ReciprocalOperatorTest {
 		MonetaryAmount result = operator.apply(money);
 		assertEquals(result.getCurrency(), currency);
 		assertEquals(result.getNumber().doubleValue(), -0.5);
-
 	}
 
 	@Test(expectedExceptions = NullPointerException.class)
-	public void shouldReturnErroWhenIsNull() {
+	public void shouldReturnErrorWhenIsNull() {
 		operator.apply(null);
-		fail();
 	}
 }


### PR DESCRIPTION
ReciprocalOperator.apply(): use BigDecimal.ONE constant instead of creation of a new BigDecimal object.
Also I added a separate commit where used static imports to make the code more concise.
Some of them like ` RoundingMode.HALF_EVEN` and `Objects.requireNonNull` are widely used across the project and in the same time their meaning is clear and not need to be scpcified with class name prefix.
So in my opinion it would be good to change them too. Will yo accept this commit? If no then I can revert it.
If you ok with that static imports then I'll send another PR with the same static import in other files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/245)
<!-- Reviewable:end -->
