### PR TITLE
Make FastMoney.divide by Zero Always throw

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java
@@ -682,6 +682,9 @@ public final class FastMoney implements MonetaryAmount, Comparable<MonetaryAmoun
         if (NumberVerifier.isInfinityAndNotNaN(divisor)) {
             return new FastMoney(0L, getCurrency());
         }
+        if (divisor == 0.0d) {
+            throw new ArithmeticException("Division by zero");
+        }
         if (divisor == 1.0d) {
             return this;
         }

--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -382,6 +382,28 @@ public class FastMoneyTest {
     }
 
     /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#divide(double)}.
+     */
+    @Test
+    public void testDivideByZeroDouble() {
+        FastMoney m = FastMoney.of(100, "CHF");
+        assertThrows(ArithmeticException.class, () -> m.divide(0.0d));
+        assertThrows(ArithmeticException.class, () -> m.divide(-0.0d));
+        assertThrows(ArithmeticException.class, () -> m.divide(Double.valueOf(0.0d)));
+        assertThrows(ArithmeticException.class, () -> m.divide(Double.valueOf(-0.0d)));
+    }
+
+    /**
+     * Test method for {@link org.javamoney.moneta.FastMoney#divide(double)}.
+     */
+    @Test
+    public void testDivideByNanDouble() {
+        FastMoney m = FastMoney.of(100, "CHF");
+        assertThrows(ArithmeticException.class, () -> m.divide(Double.NaN));
+        assertThrows(ArithmeticException.class, () -> m.divide(Double.valueOf(Double.NaN)));
+    }
+
+    /**
      * Test method for {@link org.javamoney.moneta.FastMoney#divideAndRemainder(java.lang.Number)} .
      */
     @Test


### PR DESCRIPTION
Make FastMoney.divide by Zero Always throw ArithmeticException no
matter whether the value is boxed or not.

Fixes #250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/251)
<!-- Reviewable:end -->
