### PR TITLE
Fix Codacy reference comparision warnings

### DIFF
--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -1205,10 +1205,10 @@ public class FastMoneyTest {
     public void testFromInversed() {
         Money m = Money.of(new BigDecimal("1.2345"), "XXX");
         Money m2 = Money.from(m);
-        assertTrue(m == m2);
+        assertSame(m, m2);
         FastMoney fm = FastMoney.of(new BigDecimal("1.2345"), "XXX");
         m2 = Money.from(fm);
-        assertFalse(m == m2);
+        assertNotSame(m, m2);
         assertEquals(m, m2);
     }
 

--- a/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -1129,7 +1129,7 @@ public class MoneyTest {
         ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()));
         Money m2 = (Money) ois.readObject();
         assertEquals(m, m2);
-        assertTrue(m != m2);
+        assertNotSame(m, m2);
     }
 
     // Bad cases


### PR DESCRIPTION
Codacy warns about reference comparisons in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/255)
<!-- Reviewable:end -->
