### PR TITLE
Add more divideAndRemainder tests

### DIFF
--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -103,6 +103,13 @@ public class FastMoneyTest {
       FastMoney money = FastMoney.of(original, "EUR");
       BigDecimal divisor = new BigDecimal("0.333333");
       assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(divisor));
+
+      assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(0.0d));
+      assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(-0.0d));
+      assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(Double.NaN));
+      assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(Double.valueOf(0.0d)));
+      assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(Double.valueOf(-0.0d)));
+      assertThrows(ArithmeticException.class, () -> money.divideAndRemainder(Double.valueOf(Double.NaN)));
     }
 
     @Test


### PR DESCRIPTION
Add divideAndRemainder tests for boxed and unboxed 0 and NaN.

This was requested by #250. No implementation changes are required as the methods already throw ArithmeticException.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/256)
<!-- Reviewable:end -->
