### PR TITLE
Remove getNumberStripped call from Money.equals

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/Money.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/Money.java
@@ -654,8 +654,8 @@ public final class Money implements MonetaryAmount, Comparable<MonetaryAmount>, 
         }
         if (obj instanceof Money) {
             Money other = (Money) obj;
-            return Objects.equals(getCurrency(), other.getCurrency()) &&
-                    Objects.equals(getNumberStripped(), other.getNumberStripped());
+            return getCurrency().equals(other.getCurrency()) &&
+                    this.number.compareTo(other.number) == 0;
         }
         return false;
     }

--- a/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -405,7 +405,7 @@ public class MoneyTest {
     public void testEqualsMonetaryAmount() {
         MonetaryAmount m = Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(100).create();
         MonetaryAmount m2 = Money.of(100, "CHF");
-        Money m3 = Money.of(100, "CHF");
+        Money m3 = Money.of(new BigDecimal("100.00"), "CHF");
         assertTrue(m.equals(m2));
         assertTrue(m.equals(m3));
         assertTrue(m2.equals(m3));


### PR DESCRIPTION
Money.equals currently calls getNumberStripped on the receiver and the
argument to compare two BigDecimals for equality. This ends up calling
stripTrailingZeros for both BigDecimals.
The same can be achieved without allocations using
BigDecimal.compareTo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/258)
<!-- Reviewable:end -->
