### PR TITLE
small fixes

### DIFF
--- a/moneta-convert/moneta-convert-ecb/src/test/java/org/javamoney/moneta/convert/ecb/ProviderTest.java
+++ b/moneta-convert/moneta-convert-ecb/src/test/java/org/javamoney/moneta/convert/ecb/ProviderTest.java
@@ -22,7 +22,7 @@ public class ProviderTest {
                 final ExchangeRateProvider rateProvider = MonetaryConversions.getExchangeRateProvider("ECB");
                 final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
                 final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-                System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+                System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
             }catch(Exception e){
                 e.printStackTrace();
             }
@@ -32,7 +32,7 @@ public class ProviderTest {
             final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
             Thread.sleep(100L);
             final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-            System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+            System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
         }
 
     }
@@ -45,7 +45,7 @@ public class ProviderTest {
                 final ExchangeRateProvider rateProvider = MonetaryConversions.getExchangeRateProvider("ECB-HIST90");
                 final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
                 final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-                System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+                System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
             }catch(Exception e){
                 e.printStackTrace();
             }
@@ -55,7 +55,7 @@ public class ProviderTest {
             final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
             Thread.sleep(100L);
             final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-            System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+            System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
         }
 
     }
@@ -68,7 +68,7 @@ public class ProviderTest {
                 final ExchangeRateProvider rateProvider = MonetaryConversions.getExchangeRateProvider("ECB-HIST");
                 final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
                 final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-                System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+                System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
             }catch(Exception e){
                 e.printStackTrace();
             }
@@ -78,7 +78,7 @@ public class ProviderTest {
             final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
             Thread.sleep(100L);
             final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-            System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+            System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
         }
 
     }

--- a/moneta-convert/moneta-convert-imf/src/test/java/org/javamoney/moneta/convert/imf/ProviderTest.java
+++ b/moneta-convert/moneta-convert-imf/src/test/java/org/javamoney/moneta/convert/imf/ProviderTest.java
@@ -22,7 +22,7 @@ public class ProviderTest {
                 final ExchangeRateProvider rateProvider = MonetaryConversions.getExchangeRateProvider("IMF");
                 final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
                 final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-                System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+                System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
             }catch(Exception e){
                 e.printStackTrace();
             }
@@ -32,7 +32,7 @@ public class ProviderTest {
             final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
             Thread.sleep(100L);
             final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-            System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+            System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
         }
 
     }
@@ -45,7 +45,7 @@ public class ProviderTest {
                 final ExchangeRateProvider rateProvider = MonetaryConversions.getExchangeRateProvider("IMF-HIST");
                 final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
                 final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-                System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+                System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
             }catch(Exception e){
                 e.printStackTrace();
             }
@@ -55,7 +55,7 @@ public class ProviderTest {
             final CurrencyConversion dollarConversion = rateProvider.getCurrencyConversion("USD");
             Thread.sleep(100L);
             final MonetaryAmount inDollar = inEuro.with(dollarConversion);
-            System.out.println(String.format("RUN: %n - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
+            System.out.println(String.format("RUN: %d - %s: %s ≙ %s", i, rateProvider, inEuro, inDollar));
         }
 
     }

--- a/moneta-core/src/main/java/org/javamoney/moneta/Money.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/Money.java
@@ -350,7 +350,7 @@ public final class Money implements MonetaryAmount, Comparable<MonetaryAmount>, 
 
 
     /*
-     * }(non-Javadoc)
+     * (non-Javadoc)
      *
      * @see javax.money.MonetaryAmount#query(javax.money.MonetaryQuery)
      */

--- a/moneta-core/src/main/java/org/javamoney/moneta/RoundedMoney.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/RoundedMoney.java
@@ -479,7 +479,7 @@ public final class RoundedMoney implements MonetaryAmount, Comparable<MonetaryAm
      */
     @Override
     public boolean isZero() {
-        return number.signum() == 0;
+        return signum() == 0;
     }
 
     /*

--- a/moneta-core/src/main/java/org/javamoney/moneta/RoundedMoney.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/RoundedMoney.java
@@ -640,7 +640,7 @@ public final class RoundedMoney implements MonetaryAmount, Comparable<MonetaryAm
     }
 
     /*
-     * }(non-Javadoc)
+     * (non-Javadoc)
      * @see javax.money.MonetaryAmount#adjust(javax.money.AmountAdjuster)
      */
     @Override
@@ -695,7 +695,7 @@ public final class RoundedMoney implements MonetaryAmount, Comparable<MonetaryAm
             .of(ToStringMonetaryAmountFormatStyle.ROUNDED_MONEY);
 
     /*
-     * }(non-Javadoc)
+     * (non-Javadoc)
      * @see javax.money.MonetaryAmount#adjust(javax.money.AmountAdjuster)
      */
     @Override

--- a/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/function/ReciprocalOperator.java
@@ -52,7 +52,8 @@ final class ReciprocalOperator implements MonetaryOperator {
         requireNonNull(amount, "Amount required.");
         NumberValue num = amount.getNumber();
         BigDecimal one = ONE.setScale(num.getScale() < 5 ? 5 : num.getScale(), HALF_EVEN);
-        return amount.getFactory().setNumber(one.divide(num.numberValue(BigDecimal.class), HALF_EVEN)).create();
+        BigDecimal reciprocal = one.divide(num.numberValue(BigDecimal.class), HALF_EVEN);
+        return amount.getFactory().setNumber(reciprocal).create();
     }
 
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -256,18 +256,18 @@ public class FastMoneyTest {
         FastMoney m2 = FastMoney.of(0, "CHF");
         FastMoney m3 = FastMoney.of(-0, "CHF");
         FastMoney m4 = FastMoney.of(2, "CHF");
-        assertEquals(0, m2.compareTo(m3));
-        assertEquals(0, m2.compareTo(m2));
-        assertEquals(0, m3.compareTo(m3));
-        assertEquals(0, m3.compareTo(m2));
-        assertTrue(m1.compareTo(m2) < 0);
-        assertTrue(m2.compareTo(m1) > 0);
-        assertTrue(m1.compareTo(m3) < 0);
-        assertTrue(m2.compareTo(m3) == 0);
-        assertTrue(m1.compareTo(m4) < 0);
-        assertTrue(m3.compareTo(m4) < 0);
-        assertTrue(m4.compareTo(m1) > 0);
-        assertTrue(m4.compareTo(m2) > 0);
+        assertEquals(m2.compareTo(m3), 0);
+        assertEquals(m2.compareTo(m2), 0);
+        assertEquals(m3.compareTo(m3), 0);
+        assertEquals(m3.compareTo(m2), 0);
+        assertEquals(m1.compareTo(m2), -1);
+        assertEquals(m2.compareTo(m1), 1);
+        assertEquals(m1.compareTo(m3), -1);
+        assertEquals(m2.compareTo(m3), 0);
+        assertEquals(m1.compareTo(m4), -1);
+        assertEquals(m3.compareTo(m4), -1);
+        assertEquals(m4.compareTo(m1), -1);
+        assertEquals(m4.compareTo(m2), -1);
     }
 
     /**

--- a/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/MoneyTest.java
@@ -420,18 +420,18 @@ public class MoneyTest {
         Money m2 = Money.of(0, "CHF");
         Money m3 = Money.of(-0, "CHF");
         Money m4 = Money.of(2, "CHF");
-        assertEquals(0, m2.compareTo(m3));
-        assertEquals(0, m2.compareTo(m2));
-        assertEquals(0, m3.compareTo(m3));
-        assertEquals(0, m3.compareTo(m2));
-        assertTrue(m1.compareTo(m2) < 0);
-        assertTrue(m2.compareTo(m1) > 0);
-        assertTrue(m1.compareTo(m3) < 0);
-        assertTrue(m2.compareTo(m3) == 0);
-        assertTrue(m1.compareTo(m4) < 0);
-        assertTrue(m3.compareTo(m4) < 0);
-        assertTrue(m4.compareTo(m1) > 0);
-        assertTrue(m4.compareTo(m2) > 0);
+        assertEquals(m2.compareTo(m3), 0);
+        assertEquals(m2.compareTo(m2), 0);
+        assertEquals(m3.compareTo(m3), 0);
+        assertEquals(m3.compareTo(m2), 0);
+        assertEquals(m1.compareTo(m2), -1);
+        assertEquals(m2.compareTo(m1), 1);
+        assertEquals(m1.compareTo(m3), -1);
+        assertEquals(m2.compareTo(m3), 0);
+        assertEquals(m1.compareTo(m4), -1);
+        assertEquals(m3.compareTo(m4), -1);
+        assertEquals(m4.compareTo(m1), -1);
+        assertEquals(m4.compareTo(m2), -1);
     }
 
     /**

--- a/moneta-core/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/RoundedMoneyTest.java
@@ -393,18 +393,18 @@ public class RoundedMoneyTest {
         RoundedMoney m2 = RoundedMoney.of(0, "CHF");
         RoundedMoney m3 = RoundedMoney.of(-0, "CHF");
         RoundedMoney m4 = RoundedMoney.of(2, "CHF");
-        assertEquals(0, m2.compareTo(m3));
-        assertEquals(0, m2.compareTo(m2));
-        assertEquals(0, m3.compareTo(m3));
-        assertEquals(0, m3.compareTo(m2));
-        assertTrue(m1.compareTo(m2) < 0);
-        assertTrue(m2.compareTo(m1) > 0);
-        assertTrue(m1.compareTo(m3) < 0);
-        assertTrue(m2.compareTo(m3) == 0);
-        assertTrue(m1.compareTo(m4) < 0);
-        assertTrue(m3.compareTo(m4) < 0);
-        assertTrue(m4.compareTo(m1) > 0);
-        assertTrue(m4.compareTo(m2) > 0);
+        assertEquals(m2.compareTo(m3), 0);
+        assertEquals(m2.compareTo(m2), 0);
+        assertEquals(m3.compareTo(m3), 0);
+        assertEquals(m3.compareTo(m2), 0);
+        assertEquals(m1.compareTo(m2), -1);
+        assertEquals(m2.compareTo(m1), 1);
+        assertEquals(m1.compareTo(m3), -1);
+        assertEquals(m2.compareTo(m3), 0);
+        assertEquals(m1.compareTo(m4), -1);
+        assertEquals(m3.compareTo(m4), -1);
+        assertEquals(m4.compareTo(m1), -1);
+        assertEquals(m4.compareTo(m2), -1);
     }
 
     /**

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/DefaultNumberValueTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/DefaultNumberValueTest.java
@@ -24,7 +24,7 @@ import javax.money.NumberValue;
 
 import org.testng.annotations.Test;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 public class DefaultNumberValueTest {
 


### PR DESCRIPTION
Here is small changes with cleanup and small fixes.
But I have an additional question: In the 1ca1602 commit I changed body of the `RoundedMoney.isZero()` so now it looks exactly the same as in `javax.money.MonetaryAmount#isZero`. 
In the MonetaryAmount are declared such methods:
```java
    public boolean isZero() {
        return signum() == 0;
    }

    public boolean isPositive() {
        return signum() == 1;
    }

    public boolean isPositiveOrZero() {
        return signum() >= 0;
    }

    public boolean isNegative() {
        return signum() == -1;
    }

    public boolean isNegativeOrZero() {
        return signum() <= 0;
    }
```
And all of them with exactly the same body are declared in Money and RoundingMoney.
So maybe we can just remove the  `isZero`,  `isPositive` etc methods from the Money and RoundingMoney?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/259)
<!-- Reviewable:end -->
