### PR TITLE
Use L instead of l for long literals

### DIFF
--- a/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/FastMoneyTest.java
@@ -118,7 +118,7 @@ public class FastMoneyTest {
         FastMoney result = money1.divideToIntegralValue(new BigDecimal("0.5001"));
         assertEquals(result.getNumber().numberValue(BigDecimal.class), BigDecimal.ONE);
         result = money1.divideToIntegralValue(new BigDecimal("0.2001"));
-        assertEquals(result.getNumber().numberValue(BigDecimal.class), BigDecimal.valueOf(4l));
+        assertEquals(result.getNumber().numberValue(BigDecimal.class), BigDecimal.valueOf(4L));
         result = money1.divideToIntegralValue(BigDecimal.valueOf(5));
         assertTrue(result.getNumber().numberValue(BigDecimal.class).intValueExact() == 0);
     }

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/ConvertBigDecimalTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/ConvertBigDecimalTest.java
@@ -39,7 +39,7 @@ public class ConvertBigDecimalTest {
 
 	@Test
 	public void ofLongTest() {
-		Assert.assertEquals(ConvertBigDecimal.of(10l), expectValue);
+		Assert.assertEquals(ConvertBigDecimal.of(10L), expectValue);
 	}
 
 	@Test
@@ -54,7 +54,7 @@ public class ConvertBigDecimalTest {
 
 	@Test
 	public void ofAtomicLongTest() {
-		Assert.assertEquals(ConvertBigDecimal.of(new AtomicLong(10l)), expectValue);
+		Assert.assertEquals(ConvertBigDecimal.of(new AtomicLong(10L)), expectValue);
 	}
 
 	@Test
@@ -77,6 +77,6 @@ public class ConvertBigDecimalTest {
 	}
 	@Test
 	public void ofBigIntegerTest() {
-		Assert.assertEquals(ConvertBigDecimal.of(BigInteger.valueOf(10l)), expectValue);
+		Assert.assertEquals(ConvertBigDecimal.of(BigInteger.valueOf(10L)), expectValue);
 	}
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/ConvertNumberValueTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/ConvertNumberValueTest.java
@@ -47,7 +47,7 @@ public class ConvertNumberValueTest {
 	@Test
 	public void longTest() {
 		Number valueTest = 20d;
-		Long expectedValue = 20l;
+		Long expectedValue = 20L;
 		Long number = ConvertNumberValue.of(Long.class, valueTest);
 		Long numberExact = ConvertNumberValue.ofExact(Long.class, valueTest);
 		
@@ -159,7 +159,7 @@ public class ConvertNumberValueTest {
 	@Test
 	public void atomicLongTest() {
 		Number valueTest = 20d;
-		AtomicLong expectedValue = new AtomicLong(20l);
+		AtomicLong expectedValue = new AtomicLong(20L);
 		AtomicLong number = ConvertNumberValue.of(AtomicLong.class, valueTest);
 		AtomicLong numberExact = ConvertNumberValue.ofExact(AtomicLong.class, valueTest);
 		


### PR DESCRIPTION
Using a an uppper case L instead of a lover case l for long literal
is widely recommended for example by Java Puzzlers, Puzzle 4: It's Elementary
and by the Google Java Style Guide

https://google.github.io/styleguide/javaguide.html#s4.8.8-numeric-literals

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/263)
<!-- Reviewable:end -->
