### PR TITLE
Clean up module-info

### DIFF
--- a/moneta-convert/moneta-convert-base/src/main/java/org/javamoney/moneta/convert/module-info.java
+++ b/moneta-convert/moneta-convert-base/src/main/java/org/javamoney/moneta/convert/module-info.java
@@ -1,6 +1,3 @@
-import org.javamoney.moneta.convert.internal.DefaultMonetaryConversionsSingletonSpi;
-import org.javamoney.moneta.convert.internal.IdentityRateProvider;
-
 /*
 Copyright (c) 2012, 2018, Anatole Tresch, Werner Keil and others by the @author tag.
 

--- a/moneta-convert/moneta-convert-ecb/src/main/java/org/javamoney/moneta/convert/ecb/module-info.java
+++ b/moneta-convert/moneta-convert-ecb/src/main/java/org/javamoney/moneta/convert/ecb/module-info.java
@@ -1,7 +1,3 @@
-import org.javamoney.moneta.convert.ecb.ECBCurrentRateProvider;
-import org.javamoney.moneta.convert.ecb.ECBHistoric90RateProvider;
-import org.javamoney.moneta.convert.ecb.ECBHistoricRateProvider;
-
 /*
 Copyright (c) 2012, 2018, Anatole Tresch, Werner Keil and others by the @author tag.
 

--- a/moneta-convert/moneta-convert-imf/src/main/java/org/javamoney/moneta/convert/imf/module-info.java
+++ b/moneta-convert/moneta-convert-imf/src/main/java/org/javamoney/moneta/convert/imf/module-info.java
@@ -1,6 +1,3 @@
-import org.javamoney.moneta.convert.imf.IMFHistoricRateProvider;
-import org.javamoney.moneta.convert.imf.IMFRateProvider;
-
 /*
 Copyright (c) 2012, 2018, Anatole Tresch, Werner Keil and others by the @author tag.
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/module-info.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/module-info.java
@@ -1,12 +1,3 @@
-import org.javamoney.moneta.internal.*;
-import org.javamoney.moneta.internal.format.DefaultAmountFormatProviderSpi;
-import org.javamoney.moneta.internal.loader.DefaultLoaderService;
-
-import javax.money.DefaultMonetaryRoundingsSingletonSpi;
-import javax.money.format.MonetaryFormats;
-import javax.money.format.MonetaryFormats.DefaultMonetaryFormatsSingletonSpi;
-import javax.money.spi.MonetaryFormatsSingletonSpi;
-
 /*
 Copyright (c) 2012, 2018, Anatole Tresch, Werner Keil and others by the @author tag.
 
@@ -28,7 +19,6 @@ module org.javamoney.moneta {
     exports org.javamoney.moneta.function;
     exports org.javamoney.moneta.spi;
     requires transitive java.money;
-    requires transitive java.base;
     requires transitive java.logging;
     requires java.annotation;
     requires static org.osgi.core;
@@ -42,7 +32,7 @@ module org.javamoney.moneta {
     provides javax.money.spi.MonetaryCurrenciesSingletonSpi with org.javamoney.moneta.internal.DefaultMonetaryCurrenciesSingletonSpi;
     provides javax.money.spi.RoundingProviderSpi with org.javamoney.moneta.internal.DefaultRoundingProvider;
     provides javax.money.spi.ServiceProvider with org.javamoney.moneta.internal.PriorityAwareServiceProvider;
-    provides org.javamoney.moneta.spi.LoaderService with DefaultLoaderService;
+    provides org.javamoney.moneta.spi.LoaderService with org.javamoney.moneta.internal.loader.DefaultLoaderService;
 
     uses org.javamoney.moneta.spi.LoaderService;
     uses org.javamoney.moneta.spi.MonetaryAmountProducer;


### PR DESCRIPTION
Remove imports from module-info.
There is no need to require java.base.
Modifiers on java.base are no longer allowed with Java 10+.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/264)
<!-- Reviewable:end -->
