### PR TITLE
ECBAbstractRateProvider redundant null checks

### DIFF
--- a/moneta-convert/moneta-convert-ecb/src/main/java/org/javamoney/moneta/convert/ecb/ECBAbstractRateProvider.java
+++ b/moneta-convert/moneta-convert-ecb/src/main/java/org/javamoney/moneta/convert/ecb/ECBAbstractRateProvider.java
@@ -95,11 +95,11 @@ abstract class ECBAbstractRateProvider extends AbstractRateProvider implements
 
     @Override
     public void newDataLoaded(String resourceId, InputStream is) {
-        final int oldSize = this.rates==null?0:this.rates.size();
+        final int oldSize = this.rates.size();
         try {
             SAXParser parser = saxParserFactory.newSAXParser();
             parser.parse(is, new ECBRateReadingHandler(rates, getContext()));
-            int newSize = this.rates==null?0:this.rates.size();
+            int newSize = this.rates.size();
             loadState = "Loaded " + resourceId + " exchange rates for days:" + (newSize - oldSize);
             LOG.info(loadState);
         } catch (Exception e) {


### PR DESCRIPTION
ECBAbstractRateProvider contains redundant null checks as rates can never be null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/270)
<!-- Reviewable:end -->
