### PR TITLE
Remove unnecessary Integer.toString

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/function/PrecisionScaleRoundedOperator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/function/PrecisionScaleRoundedOperator.java
@@ -104,7 +104,7 @@ public final class PrecisionScaleRoundedOperator implements MonetaryOperator {
 	@Override
 	public String toString() {
         return PrecisionScaleRoundedOperator.class.getName() + '{' +
-                "scale:" + Integer.toString(scale) + ',' +
+                "scale:" + scale + ',' +
                 "mathContext:" + mathContext + '}';
 	}
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/function/ScaleRoundedOperator.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/function/ScaleRoundedOperator.java
@@ -93,7 +93,7 @@ public final class ScaleRoundedOperator implements MonetaryOperator {
 	@Override
 	public String toString() {
         return ScaleRoundedOperator.class.getName() + '{' +
-                "scale:" + Integer.toString(scale) + ',' +
+                "scale:" + scale + ',' +
                 "roundingMode:" + roundingMode + '}';
 	}
 


### PR DESCRIPTION
In string concatenation expressions Integer.toString is not required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/271)
<!-- Reviewable:end -->
