### PR TITLE
Redundant enum constructor visibility modifiers

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DaemonThreadFactory.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/loader/DaemonThreadFactory.java
@@ -33,7 +33,7 @@ enum DaemonThreadFactory implements ThreadFactory {
 
 	private final ThreadFactory threadFactory;
 
-	private DaemonThreadFactory () {
+	DaemonThreadFactory () {
 		threadFactory = Executors.defaultThreadFactory();
 	}
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/ConvertNumberValue.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/ConvertNumberValue.java
@@ -228,7 +228,7 @@ enum ConvertNumberValue {
 	@SuppressWarnings("rawtypes")
 	private final Map<Class<? extends Number>, ConvertNumberValueI> convertIMap;
 
-	private ConvertNumberValue() {
+	ConvertNumberValue() {
 		convertIMap = new HashMap<>();
 		convertIMap.put(BigDecimal.class, new ConvertNumberValueBigDecimal());
 		convertIMap.put(BigInteger.class, new ConvertNumberValueBigInteger());


### PR DESCRIPTION
The private visibility modifier on enum constructors is redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/272)
<!-- Reviewable:end -->
