### PR TITLE
Fix parsing and formatting amounts with a space as thousand separator

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/DefaultCashRounding.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/DefaultCashRounding.java
@@ -20,7 +20,8 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Objects;
-import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation class providing cash rounding {@link javax.money.MonetaryOperator}
@@ -66,10 +67,10 @@ final class DefaultCashRounding implements MonetaryRounding, Serializable {
         if (scale < 0) {
             throw new IllegalArgumentException("scale < 0");
         }
+        requireNonNull(roundingMode, "roundingMode missing");
         this.context = RoundingContextBuilder.of("default", "default").set(CASHROUNDING_KEY, true).
                 set(PROVCLASS_KEY, getClass().getName()).set(MINMINORS_KEY, minimalMinors).set(SCALE_KEY, scale)
-                .set(Optional.ofNullable(roundingMode)
-                        .orElseThrow(() -> new IllegalArgumentException("roundingMode missing"))).build();
+                .set(roundingMode).build();
     }
 
     /**

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
@@ -108,15 +108,13 @@ final class AmountNumberToken implements FormatToken {
             throws IOException {
         if (amountFormatContext.get(AmountFormatParams.GROUPING_SIZES, int[].class) == null ||
                 amountFormatContext.get(AmountFormatParams.GROUPING_SIZES, int[].class).length == 0) {
-            appendable.append(this.formatFormat.format(amount.getNumber()
-                    .numberValue(BigDecimal.class)));
+            String preformattedValue = this.formatFormat.format(amount.getNumber().numberValue(BigDecimal.class));
+            appendable.append(preformattedValue);
             return;
         }
         this.formatFormat.setGroupingUsed(false);
-        String preformattedValue = this.formatFormat.format(amount.getNumber()
-                .numberValue(BigDecimal.class));
-        String[] numberParts = splitNumberParts(this.formatFormat,
-                preformattedValue);
+        String preformattedValue = this.formatFormat.format(amount.getNumber().numberValue(BigDecimal.class));
+        String[] numberParts = splitNumberParts(this.formatFormat, preformattedValue);
         if (numberParts.length != 2) {
             appendable.append(preformattedValue);
         } else {

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.logging.Logger;
 
 import static java.util.Objects.requireNonNull;
+import static org.javamoney.moneta.spi.MoneyUtils.replaceNbspWithSpace;
 
 /**
  * {@link FormatToken} which allows to format a {@link MonetaryAmount} type.
@@ -62,8 +63,8 @@ final class AmountNumberToken implements FormatToken {
             parseFormat.setDecimalFormatSymbols(syms);
         }
 
-        formatFormat.applyPattern(removeNBSP(partialNumberPattern));
-        parseFormat.applyPattern(removeNBSP(partialNumberPattern).trim());
+        formatFormat.applyPattern(replaceNbspWithSpace(partialNumberPattern));
+        parseFormat.applyPattern(replaceNbspWithSpace(partialNumberPattern).trim());
         // Fix for https://github.com/JavaMoney/jsr354-ri/issues/151
         if ("BG".equals(locale.getCountry())) {
             formatFormat.setGroupingSize(3);
@@ -74,14 +75,6 @@ final class AmountNumberToken implements FormatToken {
             formatFormat.setDecimalFormatSymbols(syms);
             parseFormat.setDecimalFormatSymbols(syms);
         }
-    }
-
-    /**
-     * Removes the non-breaking-space character 0x0A from the string.
-     */
-    private String removeNBSP(String s) {
-        return s.replaceAll("\\u00A0", " ");
-        // Fix for https://github.com/JavaMoney/jsr354-ri/issues/151
     }
 
     /**

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
@@ -166,4 +166,9 @@ final class AmountNumberToken implements FormatToken {
         }
     }
 
+    @Override
+    public String toString() {
+        Locale locale = amountFormatContext.getLocale();
+        return "AmountNumberToken [locale=" + locale + ", partialNumberPattern=" + partialNumberPattern + ']';
+    }
 }

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
@@ -26,8 +26,9 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link FormatToken} which allows to format a {@link MonetaryAmount} type.
@@ -44,10 +45,9 @@ final class AmountNumberToken implements FormatToken {
     private StringGrouper numberGroup;
 
     AmountNumberToken(AmountFormatContext amountFormatContext, String partialNumberPattern) {
-        this.amountFormatContext = Optional.ofNullable(amountFormatContext)
-                .orElseThrow(
-                        () -> new IllegalArgumentException(
-                                "amountFormatContext is required."));
+        requireNonNull(amountFormatContext, "amountFormatContext is required.");
+        requireNonNull(partialNumberPattern, "partialNumberPattern is required.");
+        this.amountFormatContext = amountFormatContext;
         this.partialNumberPattern = partialNumberPattern;
         initDecimalFormats();
     }
@@ -85,7 +85,7 @@ final class AmountNumberToken implements FormatToken {
     }
 
     /**
-     * Access the underlying amount fomat context.
+     * Access the underlying amount format context.
      *
      * @return the {@link javax.money.format.AmountFormatContext}.
      */

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/AmountNumberToken.java
@@ -106,8 +106,8 @@ final class AmountNumberToken implements FormatToken {
     @Override
     public void print(Appendable appendable, MonetaryAmount amount)
             throws IOException {
-        if (amountFormatContext.get(AmountFormatParams.GROUPING_SIZES, int[].class) == null ||
-                amountFormatContext.get(AmountFormatParams.GROUPING_SIZES, int[].class).length == 0) {
+        int[] groupSizes = amountFormatContext.get(AmountFormatParams.GROUPING_SIZES, int[].class);
+        if (groupSizes == null || groupSizes.length == 0) {
             String preformattedValue = this.formatFormat.format(amount.getNumber().numberValue(BigDecimal.class));
             appendable.append(preformattedValue);
             return;
@@ -123,10 +123,6 @@ final class AmountNumberToken implements FormatToken {
                 if (groupChars == null || groupChars.length == 0) {
                     groupChars = new char[]{this.formatFormat
                             .getDecimalFormatSymbols().getGroupingSeparator()};
-                }
-                int[] groupSizes = amountFormatContext.get(AmountFormatParams.GROUPING_SIZES, int[].class);
-                if (groupSizes == null) {
-                    groupSizes = new int[0];
                 }
                 numberGroup = new StringGrouper(groupChars, groupSizes);
             }

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/CurrencyToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/CurrencyToken.java
@@ -28,6 +28,9 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
+import static java.util.Objects.requireNonNull;
+import static org.javamoney.moneta.format.CurrencyStyle.CODE;
+
 /**
  * Implements a {@link FormatToken} that adds a localizable {@link String}, read
  * by key from a {@link ResourceBundle}.
@@ -38,7 +41,7 @@ final class CurrencyToken implements FormatToken {
     /**
      * The style defining, how the currency should be localized.
      */
-    private CurrencyStyle style = CurrencyStyle.CODE;
+    private CurrencyStyle style = CODE;
     /**
      * The target locale.
      */
@@ -52,8 +55,7 @@ final class CurrencyToken implements FormatToken {
      * @param locale The target locale, not {@code null}.
      */
     CurrencyToken(CurrencyStyle style, Locale locale) {
-        Objects.requireNonNull(locale, "Locale null");
-        this.locale = locale;
+        this.locale = requireNonNull(locale, "Locale null");
         if (Objects.nonNull(style)) {
             this.style = style;
         }
@@ -66,8 +68,7 @@ final class CurrencyToken implements FormatToken {
      * @return this token instance, for chaining.
      */
     public CurrencyToken setCurrencyStyle(CurrencyStyle style) {
-        Objects.requireNonNull(style, "CurrencyStyle null");
-        this.style = style;
+        this.style = requireNonNull(style, "CurrencyStyle null");
         return this;
     }
 
@@ -90,15 +91,15 @@ final class CurrencyToken implements FormatToken {
     private String getToken(MonetaryAmount amount) {
         switch (style) {
             case NUMERIC_CODE:
-                return String.valueOf(amount.getCurrency()
-                        .getNumericCode());
+                return String.valueOf(amount.getCurrency().getNumericCode());
             case NAME:
                 return getCurrencyName(amount.getCurrency());
             case SYMBOL:
                 return getCurrencySymbol(amount.getCurrency());
-            default:
             case CODE:
                 return amount.getCurrency().getCurrencyCode();
+            default:
+                throw new UnsupportedOperationException("Unexpected style " + style);
         }
     }
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
@@ -226,13 +226,8 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
         this.negativeTokens = new ArrayList<>();
         String pattern = amountFormatContext.getText("pattern");
         if (pattern == null) {
-            // Fix for https://github.com/JavaMoney/jsr354-ri/issues/151
-            if (amountFormatContext.getLocale() != null && "BG".equals(amountFormatContext.getLocale().getCountry())) {
-                pattern = "#,##0.00 ¤";
-            }else {
-                DecimalFormat currencyDecimalFormat = (DecimalFormat) DecimalFormat.getCurrencyInstance(amountFormatContext.getLocale());
-                pattern = currencyDecimalFormat.toPattern();
-            }
+            DecimalFormat currencyDecimalFormat = (DecimalFormat) DecimalFormat.getCurrencyInstance(amountFormatContext.getLocale());
+            pattern = currencyDecimalFormat.toPattern();
         }
         if (pattern.indexOf(CURRENCY_SIGN) < 0) {
             this.positiveTokens.add(new AmountNumberToken(amountFormatContext, pattern));

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
@@ -30,6 +30,8 @@ import javax.money.format.MonetaryAmountFormat;
 import javax.money.format.MonetaryParseException;
 import org.javamoney.moneta.format.CurrencyStyle;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Formats instances of {@code MonetaryAmount} to a {@link String} or an
  * {@link Appendable}.
@@ -220,8 +222,7 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
     }
 
     private void setAmountFormatContext(AmountFormatContext amountFormatContext) {
-        Objects.requireNonNull(amountFormatContext);
-        this.amountFormatContext = amountFormatContext;
+        this.amountFormatContext = requireNonNull(amountFormatContext);
         this.positiveTokens = new ArrayList<>();
         this.negativeTokens = new ArrayList<>();
         String pattern = amountFormatContext.getText("pattern");

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
@@ -46,17 +46,15 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
     /**
      * The international Unicode currency sign.
      */
-    private static final char CURRENCY_SIGN = '\u00A4';
+    private static final char CURRENCY_SIGN = '¤';
 
     /**
-     * The tokens to be used for formatting/parsing of positive and zero
-     * numbers.
+     * The tokens to be used for formatting/parsing of positive and zero numbers.
      */
     private List<FormatToken> positiveTokens;
 
     /**
-     * The tokens to be used for formatting/parsing of positive and zero
-     * numbers.
+     * The tokens to be used for formatting/parsing of negative numbers.
      */
     private List<FormatToken> negativeTokens;
 
@@ -122,6 +120,7 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
      * @return the string printed using the settings of this formatter
      * @throws UnsupportedOperationException if the formatter is unable to print
      */
+    @Override
     public String format(MonetaryAmount amount) {
         StringBuilder builder = new StringBuilder();
         try {
@@ -143,6 +142,7 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
      * @param amount     the amount to print, not null
      * @throws IOException if an IO error occurs
      */
+    @Override
     public void print(Appendable appendable, MonetaryAmount amount)
             throws IOException {
         if (amount.isNegative()) {
@@ -169,6 +169,7 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
      * @throws UnsupportedOperationException             if the formatter is unable to parse
      * @throws javax.money.format.MonetaryParseException if there is a problem while parsing
      */
+    @Override
     public MonetaryAmount parse(CharSequence text)
             throws MonetaryParseException {
         ParseContext ctx = new ParseContext(text);

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormat.java
@@ -75,19 +75,19 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
         setAmountFormatContext(amountFormatContext);
     }
 
-    private void initPattern(String pattern, List<FormatToken> tokens,
-                             AmountFormatContext style) {
+    private void initPattern(String pattern, List<FormatToken> tokens, AmountFormatContext style) {
         int index = pattern.indexOf(CURRENCY_SIGN);
+        Locale locale = style.get(Locale.class);
+        CurrencyStyle currencyStyle = style.get(CurrencyStyle.class);
         if (index > 0) { // currency placement after, between
             String p1 = pattern.substring(0, index);
             String p2 = pattern.substring(index + 1);
             if (isLiteralPattern(p1)) {
                 tokens.add(new LiteralToken(p1));
-                tokens.add(new CurrencyToken(style.get(CurrencyStyle.class), style.
-                        get(Locale.class)));
+                tokens.add(new CurrencyToken(currencyStyle, locale));
             } else {
                 tokens.add(new AmountNumberToken(style, p1));
-                tokens.add(new CurrencyToken(style.get(CurrencyStyle.class), style.get(Locale.class)));
+                tokens.add(new CurrencyToken(currencyStyle, locale));
             }
             if (!p2.isEmpty()) {
                 if (isLiteralPattern(p2)) {
@@ -97,8 +97,7 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
                 }
             }
         } else if (index == 0) { // currency placement before
-            tokens.add(new CurrencyToken(style.get(CurrencyStyle.class), style
-                    .get(Locale.class)));
+            tokens.add(new CurrencyToken(currencyStyle, locale));
             tokens.add(new AmountNumberToken(style, pattern.substring(1)));
         } else { // no currency
             tokens.add(new AmountNumberToken(style, pattern));
@@ -231,7 +230,8 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
             if (amountFormatContext.getLocale() != null && "BG".equals(amountFormatContext.getLocale().getCountry())) {
                 pattern = "#,##0.00 ¤";
             }else {
-                pattern = ((DecimalFormat) DecimalFormat.getCurrencyInstance(amountFormatContext.getLocale())).toPattern();
+                DecimalFormat currencyDecimalFormat = (DecimalFormat) DecimalFormat.getCurrencyInstance(amountFormatContext.getLocale());
+                pattern = currencyDecimalFormat.toPattern();
             }
         }
         if (pattern.indexOf(CURRENCY_SIGN) < 0) {
@@ -240,8 +240,9 @@ final class DefaultMonetaryAmountFormat implements MonetaryAmountFormat {
         } else {
             // split into (potential) plus, minus patterns
             char patternSeparator = ';';
-            if (Objects.nonNull(amountFormatContext.get(DecimalFormatSymbols.class))) {
-                patternSeparator = amountFormatContext.get(DecimalFormatSymbols.class).getPatternSeparator();
+            DecimalFormatSymbols decimalFormatSymbols = amountFormatContext.get(DecimalFormatSymbols.class);
+            if (Objects.nonNull(decimalFormatSymbols)) {
+                patternSeparator = decimalFormatSymbols.getPatternSeparator();
             }
             String[] plusMinusPatterns = pattern.split(String.valueOf(patternSeparator));
             initPattern(plusMinusPatterns[0], this.positiveTokens, amountFormatContext);

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/LiteralToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/LiteralToken.java
@@ -17,10 +17,11 @@ package org.javamoney.moneta.internal.format;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Optional;
 
 import javax.money.MonetaryAmount;
 import javax.money.format.MonetaryParseException;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link FormatToken} which adds an arbitrary literal constant value to the
@@ -48,8 +49,7 @@ final class LiteralToken implements FormatToken, Serializable {
      * @param token The literal token part.
      */
     LiteralToken(String token) {
-        this.token = Optional.ofNullable(token).orElseThrow(
-                () -> new IllegalArgumentException("Token is required."));
+        this.token = requireNonNull(token, "Token is required.");
     }
 
     /**

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/LiteralToken.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/LiteralToken.java
@@ -58,11 +58,11 @@ final class LiteralToken implements FormatToken, Serializable {
      * @see org.javamoney.moneta.internal.format.FormatToken#parse(ParseContext)
      */
     @Override
-    public void parse(ParseContext context)
-            throws MonetaryParseException {
+    public void parse(ParseContext context) throws MonetaryParseException {
         if (!context.consume(token)) {
-            throw new MonetaryParseException(context.getOriginalInput(),
-                    context.getErrorIndex());
+            context.setError();
+            context.setErrorMessage("Parse Error");
+            throw new MonetaryParseException(context.getOriginalInput(), context.getErrorIndex());
         }
     }
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
@@ -127,7 +127,8 @@ final class ParseContext {
      */
     public int skipWhitespace() {
         for (int i = index; i < originalInput.length(); i++) {
-            if (Character.isWhitespace(originalInput.charAt(i))) {
+            char ch = originalInput.charAt(i);
+            if (Character.isWhitespace(ch)) {
                 index++;
             } else {
                 break;
@@ -256,7 +257,8 @@ final class ParseContext {
         skipWhitespace();
         int start = index;
         for (int end = index; end < originalInput.length(); end++) {
-            if (Character.isWhitespace(originalInput.charAt(end))) {
+            char ch = originalInput.charAt(end);
+            if (Character.isWhitespace(ch)) {
                 if (end > start) {
                     return originalInput.subSequence(start, end).toString();
                 }

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
@@ -23,6 +23,7 @@ import javax.money.MonetaryAmount;
 import javax.money.format.MonetaryAmountFormat;
 
 import static java.util.Objects.requireNonNull;
+import static org.javamoney.moneta.spi.MoneyUtils.replaceNbspWithSpace;
 
 /**
  * Context passed along to each {@link FormatToken} in-line, when parsing an
@@ -65,7 +66,8 @@ final class ParseContext {
      * @param text The test to be parsed.
      */
     ParseContext(CharSequence text) {
-        this.originalInput = requireNonNull(text, "text is required");
+        requireNonNull(text, "text is required");
+        this.originalInput = replaceNbspWithSpace(text.toString());
     }
 
     /**
@@ -259,7 +261,7 @@ final class ParseContext {
         int start = index;
         for (int end = index; end < originalInput.length(); end++) {
             char ch = originalInput.charAt(end);
-            if (Character.isWhitespace(ch)) {
+            if (Character.isSpaceChar(ch)) {
                 if (end > start) {
                     return originalInput.subSequence(start, end).toString();
                 }

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
@@ -128,7 +128,7 @@ final class ParseContext {
     public int skipWhitespace() {
         for (int i = index; i < originalInput.length(); i++) {
             char ch = originalInput.charAt(i);
-            if (Character.isWhitespace(ch)) {
+            if (Character.isSpaceChar(ch) ) {
                 index++;
             } else {
                 break;

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
@@ -17,11 +17,12 @@ package org.javamoney.moneta.internal.format;
 
 import java.text.ParsePosition;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.money.CurrencyUnit;
 import javax.money.MonetaryAmount;
 import javax.money.format.MonetaryAmountFormat;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Context passed along to each {@link FormatToken} in-line, when parsing an
@@ -64,8 +65,7 @@ final class ParseContext {
      * @param text The test to be parsed.
      */
     ParseContext(CharSequence text) {
-        this.originalInput = Optional.ofNullable(text).orElseThrow(
-                () -> new IllegalArgumentException("text is required"));
+        this.originalInput = requireNonNull(text, "text is required");
     }
 
     /**
@@ -214,7 +214,7 @@ final class ParseContext {
      * @param number The result number
      */
     public void setParsedNumber(Number number) {
-        this.parsedNumber = number;
+        this.parsedNumber = requireNonNull(number);
     }
 
     /**
@@ -223,7 +223,7 @@ final class ParseContext {
      * @param currency The parsed currency
      */
     public void setParsedCurrency(CurrencyUnit currency) {
-        this.parsedCurrency = currency;
+        this.parsedCurrency = requireNonNull(currency);
     }
 
     /**
@@ -297,7 +297,6 @@ final class ParseContext {
     }
 
     public void setErrorMessage(String message) {
-        Objects.requireNonNull(message);
-        this.errorMessage = message;
+        this.errorMessage = requireNonNull(message);;
     }
 }

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/ParseContext.java
@@ -207,6 +207,7 @@ final class ParseContext {
         this.errorIndex = -1;
         this.parsedNumber = null;
         this.parsedCurrency = null;
+        this.errorMessage = null;
     }
 
     /**

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/format/StringGrouper.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/format/StringGrouper.java
@@ -15,7 +15,7 @@
  */
 package org.javamoney.moneta.internal.format;
 
-import java.util.Optional;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Small utility class that supports flexible grouping of an input String using
@@ -47,10 +47,7 @@ final class StringGrouper {
 	}
 
 	public StringGrouper setGroupChars(char... groupCharacters) {
-		this.groupCharacters = Optional.ofNullable(groupCharacters)
-				.orElseThrow(
-						() -> new IllegalArgumentException(
-								"groupCharacters is required."));
+		this.groupCharacters = requireNonNull(groupCharacters, "groupCharacters is required.");
 		return this;
 	}
 
@@ -63,11 +60,7 @@ final class StringGrouper {
 	}
 
 	public StringGrouper setGroupSizes(int... groupSizes) {
-		this.groupSizes = Optional
-				.ofNullable(groupSizes)
-				.orElseThrow(
-						() -> new IllegalArgumentException(
-								"groupSizes is required.")).clone();
+		this.groupSizes = requireNonNull(groupSizes, "groupSizes is required.").clone();
 		return this;
 	}
 

--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/MoneyUtils.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/MoneyUtils.java
@@ -43,6 +43,7 @@ public final class MoneyUtils {
      * The logger used.
      */
     private static final Logger LOG = Logger.getLogger(MoneyUtils.class.getName());
+    public static final char NBSP = '\u00A0';
 
     private MoneyUtils() {
     }
@@ -156,4 +157,10 @@ public final class MoneyUtils {
         Objects.requireNonNull(number, "Number is required.");
     }
 
+    /**
+     * Replaces the non-breaking-space character 0x0A from the string with usual space.
+     */
+    public static String replaceNbspWithSpace(String s) {
+        return s.replace(NBSP, ' ');
+    }
 }

--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/MoneyUtils.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/MoneyUtils.java
@@ -44,6 +44,7 @@ public final class MoneyUtils {
      */
     private static final Logger LOG = Logger.getLogger(MoneyUtils.class.getName());
     public static final char NBSP = '\u00A0';
+    public static final char NNBSP = '\u202F';
 
     private MoneyUtils() {
     }
@@ -158,9 +159,10 @@ public final class MoneyUtils {
     }
 
     /**
-     * Replaces the non-breaking-space character 0x0A from the string with usual space.
+     * Replaces the non-breaking space character U+00A0 and Narrow non-breaking space U+202F from the string with usual space.
+     * https://en.wikipedia.org/wiki/Non-breaking_space}
      */
     public static String replaceNbspWithSpace(String s) {
-        return s.replace(NBSP, ' ');
+        return s.replace(NBSP, ' ').replace(NNBSP, ' ');
     }
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/TestCurrency.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/TestCurrency.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Adapter that implements the new {@link CurrencyUnit} interface using the
  * JDK's {@link Currency}.
@@ -96,14 +98,17 @@ public final class TestCurrency implements CurrencyUnit, Serializable, Comparabl
         return cu;
     }
 
+    @Override
     public String getCurrencyCode() {
         return currencyCode;
     }
 
+    @Override
     public int getNumericCode() {
         return numericCode;
     }
 
+    @Override
     public int getDefaultFractionDigits() {
         return defaultFractionDigits;
     }
@@ -113,6 +118,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable, Comparabl
         return CONTEXT;
     }
 
+    @Override
     public int compareTo(CurrencyUnit currency) {
         Objects.requireNonNull(currency);
         return getCurrencyCode().compareTo(currency.getCurrencyCode());
@@ -150,8 +156,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable, Comparabl
         }
 
         public Builder withCurrencyCode(String currencyCode) {
-            this.currencyCode = Optional.ofNullable(currencyCode)
-                    .orElseThrow(() -> new IllegalArgumentException("currencyCode may not be null."));
+            this.currencyCode = requireNonNull(currencyCode, "currencyCode may not be null.");
             return this;
         }
 
@@ -222,8 +227,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable, Comparabl
          * @param currency the JDK currency instance
          */
         private JDKCurrencyAdapter(Currency currency) {
-            this.currency =
-                    Optional.ofNullable(currency).orElseThrow(() -> new IllegalArgumentException("Currency required."));
+            this.currency = requireNonNull(currency, "Currency required.");
         }
 
         @Override

--- a/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
@@ -19,10 +19,10 @@ import static java.util.Locale.FRANCE;
 import static org.javamoney.moneta.format.CurrencyStyle.CODE;
 import static org.testng.Assert.assertEquals;
 
-import java.math.BigDecimal;
 import java.util.Locale;
 
 import javax.money.MonetaryAmount;
+import javax.money.format.AmountFormatQuery;
 import javax.money.format.AmountFormatQueryBuilder;
 import javax.money.format.MonetaryAmountFormat;
 import javax.money.format.MonetaryFormats;
@@ -37,10 +37,8 @@ public class MonetaryFormatsTest {
 
     @Test(enabled = false)
     public void testParse_DKK_da() {
-         MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(DANISH)
-                        .set(CODE)
-                        .build());
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(DANISH).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
         MonetaryAmount amountOk = format.parse("123,01 DKK");
         MonetaryAmount amountKo = format.parse("14 000,12 DKK");
         assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
@@ -49,10 +47,8 @@ public class MonetaryFormatsTest {
 
     @Test(enabled = false) // FIXME this seems totally wrong, expected [14 000,12 EUR] but found [14 000,12 EUR] why does it work for Lev but not Euro?
     public void testFormat_EUR_fr_FR() {
-        MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(FRANCE)
-                        .set(CODE)
-                        .build());
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(FRANCE).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
         MonetaryAmount amount = Money.of(14000.12, "EUR");
         String formatted = format.format(amount);
         assertEquals(formatted, "14 000,12 EUR");
@@ -60,10 +56,8 @@ public class MonetaryFormatsTest {
 
     @Test(enabled = false)
     public void testParse_EUR_fr_FR() {
-        MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(FRANCE)
-                        .set(CODE)
-                        .build());
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(FRANCE).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
         MonetaryAmount amountOk = format.parse("123,01 EUR");
         MonetaryAmount amountKo = format.parse("14 000,12 EUR");
         assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
@@ -72,10 +66,8 @@ public class MonetaryFormatsTest {
 
     @Test(enabled = false)
     public void testParse_BGN_bg_BG() {
-        MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(BULGARIA)
-                        .set(CODE)
-                        .build());
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(BULGARIA).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
         MonetaryAmount amountOk = format.parse("123,01 BGN");
         MonetaryAmount amountKo = format.parse("14 000,12 BGN");
         assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
@@ -84,10 +76,8 @@ public class MonetaryFormatsTest {
 
     @Test
     public void testFormat_BGN_bg_BG() {
-        MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(BULGARIA)
-                        .set(CODE)
-                        .build());
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(BULGARIA).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
         MonetaryAmount amount = Money.of(14000.12, "BGN");
         String formatted = format.format(amount);
         assertEquals(formatted, "14 000,12 BGN");
@@ -99,11 +89,11 @@ public class MonetaryFormatsTest {
      */
     @Test(enabled = false)
     public void testFormat_INR_en_IN() {
-        BigDecimal amount = new BigDecimal("67890000000000");
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(INDIA);
-        Money money = Money.of(amount, "INR");
+        Money money = Money.of(67890000000000L, "INR");
         String expectedFormattedString = "INR 6,78,90,00,00,00,000.00";
-        assertEquals(format.format(money), expectedFormattedString);
+        String formatted = format.format(money);
+        assertEquals(formatted, expectedFormattedString);
         assertEquals(money, Money.parse(expectedFormattedString, format));
     }
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
@@ -15,6 +15,8 @@
  */
 package org.javamoney.moneta.format;
 
+import static java.util.Locale.FRANCE;
+import static org.javamoney.moneta.format.CurrencyStyle.CODE;
 import static org.testng.Assert.assertEquals;
 
 import java.math.BigDecimal;
@@ -29,72 +31,72 @@ import org.javamoney.moneta.Money;
 import org.testng.annotations.Test;
 
 public class MonetaryFormatsTest {
-	
-	@Test(enabled = false)
-	public void testParseDK() {
-		final Locale.Builder localeBuilder = new Locale.Builder();
-		localeBuilder.setLanguage("da"); // Danish
-	    MonetaryAmountFormat format = MonetaryFormats
-	            .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
-	                    .set(CurrencyStyle.CODE)
-	                    .build());
-	    MonetaryAmount amountOk = format.parse("123,01 DKK");
-	    MonetaryAmount amountKo = format.parse("14 000,12 DKK");
-	    assertEquals(amountOk.getNumber().doubleValueExact(), 123.01); // OK
-	    assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12); // KO
-	}
-	
-	@Test(enabled = false) // FIXME this seems totally wrong, expected [14 000,12 EUR] but found [14 000,12 EUR] why does it work for Lev but not Euro?
-	public void testFormatFR() {
-	    MonetaryAmountFormat format = MonetaryFormats
-	            .getAmountFormat(AmountFormatQueryBuilder.of(Locale.FRANCE)
-	                    .set(CurrencyStyle.CODE)
-	                    .build());
-	    MonetaryAmount amount = Money.of(14000.12, "EUR");
-	    String formatted = format.format(amount);
-	    assertEquals(formatted, "14 000,12 EUR");
-	}  
-	
-	@Test(enabled = false)
-	public void testParseFR() {
-	    MonetaryAmountFormat format = MonetaryFormats
-	            .getAmountFormat(AmountFormatQueryBuilder.of(Locale.FRANCE)
-	                    .set(CurrencyStyle.CODE)
-	                    .build());
-	    MonetaryAmount amountOk = format.parse("123,01 EUR");
-	    MonetaryAmount amountKo = format.parse("14 000,12 EUR");
-	    assertEquals(amountOk.getNumber().doubleValueExact(), 123.01); // OK
-	    assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12); // KO
-	}
-	
-	@Test(enabled = false)
-	public void testParseBG() {
-		final Locale.Builder localeBuilder = new Locale.Builder();
-		localeBuilder.setRegion("BG"); // BG
-	    MonetaryAmountFormat format = MonetaryFormats
-	            .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
-	                    .set(CurrencyStyle.CODE)
-	                    .build());
-	    MonetaryAmount amountOk = format.parse("123,01 BGN");
-	    MonetaryAmount amountKo = format.parse("14 000,12 BGN");
-	    assertEquals(amountOk.getNumber().doubleValueExact(), 123.01); // OK
-	    assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12); // KO
-	}
-	
-	@Test
-	public void testFormatBG() {
-		final Locale.Builder localeBuilder = new Locale.Builder();
-		localeBuilder.setRegion("BG"); // BG
-	    MonetaryAmountFormat format = MonetaryFormats
-	            .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
-	                    .set(CurrencyStyle.CODE)
-	                    .build());
-	    MonetaryAmount amount = Money.of(14000.12, "BGN");
-	    String formatted = format.format(amount);
-	    assertEquals(formatted, "14 000,12 BGN");
-	}    	
-	
-	/**
+
+    @Test(enabled = false)
+    public void testParseDK() {
+        final Locale.Builder localeBuilder = new Locale.Builder();
+        localeBuilder.setLanguage("da"); // Danish
+        MonetaryAmountFormat format = MonetaryFormats
+                .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
+                        .set(CODE)
+                        .build());
+        MonetaryAmount amountOk = format.parse("123,01 DKK");
+        MonetaryAmount amountKo = format.parse("14 000,12 DKK");
+        assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
+        assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12);
+    }
+
+    @Test(enabled = false) // FIXME this seems totally wrong, expected [14 000,12 EUR] but found [14 000,12 EUR] why does it work for Lev but not Euro?
+    public void testFormatFR() {
+        MonetaryAmountFormat format = MonetaryFormats
+                .getAmountFormat(AmountFormatQueryBuilder.of(FRANCE)
+                        .set(CODE)
+                        .build());
+        MonetaryAmount amount = Money.of(14000.12, "EUR");
+        String formatted = format.format(amount);
+        assertEquals(formatted, "14 000,12 EUR");
+    }
+
+    @Test(enabled = false)
+    public void testParseFR() {
+        MonetaryAmountFormat format = MonetaryFormats
+                .getAmountFormat(AmountFormatQueryBuilder.of(FRANCE)
+                        .set(CODE)
+                        .build());
+        MonetaryAmount amountOk = format.parse("123,01 EUR");
+        MonetaryAmount amountKo = format.parse("14 000,12 EUR");
+        assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
+        assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12);
+    }
+
+    @Test(enabled = false)
+    public void testParseBG() {
+        final Locale.Builder localeBuilder = new Locale.Builder();
+        localeBuilder.setRegion("BG"); // BG
+        MonetaryAmountFormat format = MonetaryFormats
+                .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
+                        .set(CODE)
+                        .build());
+        MonetaryAmount amountOk = format.parse("123,01 BGN");
+        MonetaryAmount amountKo = format.parse("14 000,12 BGN");
+        assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
+        assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12);
+    }
+
+    @Test
+    public void testFormatBG() {
+        final Locale.Builder localeBuilder = new Locale.Builder();
+        localeBuilder.setRegion("BG"); // BG
+        MonetaryAmountFormat format = MonetaryFormats
+                .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
+                        .set(CODE)
+                        .build());
+        MonetaryAmount amount = Money.of(14000.12, "BGN");
+        String formatted = format.format(amount);
+        assertEquals(formatted, "14 000,12 BGN");
+    }
+
+    /**
      * Test related to parsing and formatting for India.
      * https://github.com/JavaMoney/jsr354-ri/issues/275
      */

--- a/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
@@ -31,13 +31,14 @@ import org.javamoney.moneta.Money;
 import org.testng.annotations.Test;
 
 public class MonetaryFormatsTest {
+    private static final Locale DANISH = new Locale("da");
+    private static final Locale BULGARIA = new Locale("bg", "BG");
+    public static final Locale INDIA = new Locale("en, IN");
 
     @Test(enabled = false)
-    public void testParseDK() {
-        final Locale.Builder localeBuilder = new Locale.Builder();
-        localeBuilder.setLanguage("da"); // Danish
-        MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
+    public void testParse_DKK_da() {
+         MonetaryAmountFormat format = MonetaryFormats
+                .getAmountFormat(AmountFormatQueryBuilder.of(DANISH)
                         .set(CODE)
                         .build());
         MonetaryAmount amountOk = format.parse("123,01 DKK");
@@ -47,7 +48,7 @@ public class MonetaryFormatsTest {
     }
 
     @Test(enabled = false) // FIXME this seems totally wrong, expected [14 000,12 EUR] but found [14 000,12 EUR] why does it work for Lev but not Euro?
-    public void testFormatFR() {
+    public void testFormat_EUR_fr_FR() {
         MonetaryAmountFormat format = MonetaryFormats
                 .getAmountFormat(AmountFormatQueryBuilder.of(FRANCE)
                         .set(CODE)
@@ -58,7 +59,7 @@ public class MonetaryFormatsTest {
     }
 
     @Test(enabled = false)
-    public void testParseFR() {
+    public void testParse_EUR_fr_FR() {
         MonetaryAmountFormat format = MonetaryFormats
                 .getAmountFormat(AmountFormatQueryBuilder.of(FRANCE)
                         .set(CODE)
@@ -70,11 +71,9 @@ public class MonetaryFormatsTest {
     }
 
     @Test(enabled = false)
-    public void testParseBG() {
-        final Locale.Builder localeBuilder = new Locale.Builder();
-        localeBuilder.setRegion("BG"); // BG
+    public void testParse_BGN_bg_BG() {
         MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
+                .getAmountFormat(AmountFormatQueryBuilder.of(BULGARIA)
                         .set(CODE)
                         .build());
         MonetaryAmount amountOk = format.parse("123,01 BGN");
@@ -84,11 +83,9 @@ public class MonetaryFormatsTest {
     }
 
     @Test
-    public void testFormatBG() {
-        final Locale.Builder localeBuilder = new Locale.Builder();
-        localeBuilder.setRegion("BG"); // BG
+    public void testFormat_BGN_bg_BG() {
         MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(localeBuilder.build())
+                .getAmountFormat(AmountFormatQueryBuilder.of(BULGARIA)
                         .set(CODE)
                         .build());
         MonetaryAmount amount = Money.of(14000.12, "BGN");
@@ -97,15 +94,13 @@ public class MonetaryFormatsTest {
     }
 
     /**
-     * Test related to parsing and formatting for India.
+     * Test related to parsing and formatting Rupees for India.
      * https://github.com/JavaMoney/jsr354-ri/issues/275
      */
     @Test(enabled = false)
-    public void testRupeeFormatting() {
+    public void testFormat_INR_en_IN() {
         BigDecimal amount = new BigDecimal("67890000000000");
-        Locale india = new Locale("en, IN");
-
-        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(india);
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(INDIA);
         Money money = Money.of(amount, "INR");
         String expectedFormattedString = "INR 6,78,90,00,00,00,000.00";
         assertEquals(format.format(money), expectedFormattedString);

--- a/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/format/MonetaryFormatsTest.java
@@ -15,7 +15,9 @@
  */
 package org.javamoney.moneta.format;
 
+import static java.util.Locale.CHINA;
 import static java.util.Locale.FRANCE;
+import static java.util.Locale.GERMANY;
 import static org.javamoney.moneta.format.CurrencyStyle.CODE;
 import static org.testng.Assert.assertEquals;
 
@@ -35,65 +37,119 @@ public class MonetaryFormatsTest {
     private static final Locale BULGARIA = new Locale("bg", "BG");
     public static final Locale INDIA = new Locale("en, IN");
 
-    @Test(enabled = false)
+    @Test
     public void testParse_DKK_da() {
         AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(DANISH).set(CODE).build();
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
-        MonetaryAmount amountOk = format.parse("123,01 DKK");
-        MonetaryAmount amountKo = format.parse("14 000,12 DKK");
-        assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
-        assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12);
+        assertMoneyParse(format, "123 DKK", 123.0, "DKK");
+        assertMoneyParse(format, "123,01 DKK", 123.01, "DKK");
+        assertMoneyParse(format, "14.000,12 DKK", 14000.12, "DKK");
+        assertMoneyParse(format, "14.000,12\u00A0DKK", 14000.12, "DKK");
     }
 
-    @Test(enabled = false) // FIXME this seems totally wrong, expected [14 000,12 EUR] but found [14 000,12 EUR] why does it work for Lev but not Euro?
-    public void testFormat_EUR_fr_FR() {
-        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(FRANCE).set(CODE).build();
+    @Test
+    public void testFormat_DKK_da() {
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(DANISH).set(CODE).build();
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
-        MonetaryAmount amount = Money.of(14000.12, "EUR");
-        String formatted = format.format(amount);
-        assertEquals(formatted, "14 000,12 EUR");
+        assertMoneyFormat(format,  Money.of(123.01, "DKK"), "123,01 DKK");
+        assertMoneyFormat(format, Money.of(14000.12, "DKK"), "14.000,12 DKK");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testParse_EUR_fr_FR() {
         AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(FRANCE).set(CODE).build();
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
-        MonetaryAmount amountOk = format.parse("123,01 EUR");
-        MonetaryAmount amountKo = format.parse("14 000,12 EUR");
-        assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
-        assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12);
+        assertMoneyParse(format, "123 EUR", 123.0, "EUR");
+        assertMoneyParse(format, "123,01 EUR", 123.01, "EUR");
+        assertMoneyParse(format, "14 000,12 EUR", 14000.12, "EUR");
+        assertMoneyParse(format, "14\u00A0000,12\u00A0EUR", 14000.12, "EUR");
+        assertMoneyParse(format, "14\u202F000,12\u00A0EUR", 14000.12, "EUR");
     }
 
-    @Test(enabled = false)
+    @Test
+    public void testFormat_EUR_fr_FR() {
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(FRANCE).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
+        assertMoneyFormat(format,  Money.of(123.01, "EUR"), "123,01 EUR");
+        assertMoneyFormat(format,  Money.of(14000.12, "EUR"), "14 000,12 EUR");
+    }
+
+    @Test
     public void testParse_BGN_bg_BG() {
         AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(BULGARIA).set(CODE).build();
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
-        MonetaryAmount amountOk = format.parse("123,01 BGN");
-        MonetaryAmount amountKo = format.parse("14 000,12 BGN");
-        assertEquals(amountOk.getNumber().doubleValueExact(), 123.01);
-        assertEquals(amountKo.getNumber().doubleValueExact(), 14000.12);
+        assertMoneyParse(format, "123 BGN", 123.0, "BGN");
+        assertMoneyParse(format, "123,01 BGN", 123.01, "BGN");
+        assertMoneyParse(format, "14 000,12 BGN", 14000.12, "BGN");
+        assertMoneyParse(format, "14\u00A0000,12\u00A0BGN", 14000.12, "BGN");
     }
 
     @Test
     public void testFormat_BGN_bg_BG() {
         AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(BULGARIA).set(CODE).build();
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
-        MonetaryAmount amount = Money.of(14000.12, "BGN");
-        String formatted = format.format(amount);
-        assertEquals(formatted, "14 000,12 BGN");
+        assertMoneyFormat(format,  Money.of(123.01, "BGN"), "123,01 BGN");
+        assertMoneyFormat(format, Money.of(14000.12, "BGN"), "14 000,12 BGN");
     }
 
-    /**
-     * Test related to parsing and formatting Rupees for India.
-     * https://github.com/JavaMoney/jsr354-ri/issues/275
-     */
-    @Test(enabled = false)
+    @Test
+    public void testParse_EUR_de_DE() {
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(GERMANY).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
+        assertMoneyParse(format, "123 EUR", 123.0, "EUR");
+        assertMoneyParse(format, "123,01 EUR", 123.01, "EUR");
+        assertMoneyParse(format, "14.000,12 EUR", 14000.12, "EUR");
+        assertMoneyParse(format, "14.000,12\u00A0EUR", 14000.12, "EUR");
+    }
+
+    @Test
+    public void testFormat_EUR_de_DE() {
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(GERMANY).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
+        assertMoneyFormat(format, Money.of(123.01, "EUR"), "123,01 EUR");
+        assertMoneyFormat(format, Money.of(14000.12, "EUR"), "14.000,12 EUR");
+    }
+
+    @Test
+    public void testParse_INR_en_IN() {
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(INDIA);
+        assertMoneyParse(format, "INR 6,78,90,00,00,00,000.00", 67890000000000L, "INR");
+    }
+
+    @Test
     public void testFormat_INR_en_IN() {
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(INDIA);
-        Money money = Money.of(67890000000000L, "INR");
-        String expectedFormattedString = "INR 6,78,90,00,00,00,000.00";
-        String formatted = format.format(money);
-        assertEquals(formatted, expectedFormattedString);
-        assertEquals(money, Money.parse(expectedFormattedString, format));
+        assertMoneyFormat(format, Money.of(67890000000000L, "INR"), "INR 67,890,000,000,000.00");
+//TODO        assertMoneyFormat(format, Money.of(67890000000000L, "INR"), "INR 6,78,90,00,00,00,000.00");
+    }
+
+    @Test
+    public void testParse_CNY_zh_CN() {
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(CHINA).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
+        assertMoneyParse(format, "CNY123", 123.0, "CNY");
+        assertMoneyParse(format, "CNY123.01", 123.01, "CNY");
+        assertMoneyParse(format, "CNY14,000.12", 14000.12, "CNY");
+        assertMoneyParse(format, "CNY 14,000.12", 14000.12, "CNY");
+        assertMoneyParse(format, "CNY\u00A014,000.12", 14000.12, "CNY");
+    }
+
+    @Test
+    public void testFormat_CNY_zh_CN() {
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(CHINA).set(CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
+        assertMoneyFormat(format, Money.of(123.01, "CNY"), "CNY123.01");
+        assertMoneyFormat(format, Money.of(14000.12, "CNY"), "CNY14,000.12");
+    }
+
+    private void assertMoneyParse(MonetaryAmountFormat format, String text, double expected, String currencyCode) {
+        MonetaryAmount amountInt = format.parse(text);
+        assertEquals(amountInt.getNumber().doubleValueExact(), expected);
+        assertEquals(amountInt.getCurrency().getCurrencyCode(), currencyCode);
+    }
+
+    private void assertMoneyFormat(MonetaryAmountFormat format, MonetaryAmount amount, String expected) {
+        String formatted = format.format(amount);
+        assertEquals(formatted, expected);
     }
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/AmountNumberTokenTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/AmountNumberTokenTest.java
@@ -1,0 +1,31 @@
+package org.javamoney.moneta.internal.format;
+
+import org.testng.annotations.Test;
+
+import javax.money.format.*;
+import java.util.Locale;
+
+import static java.util.Locale.*;
+import static org.javamoney.moneta.format.CurrencyStyle.CODE;
+import static org.testng.Assert.*;
+
+public class AmountNumberTokenTest {
+    private static final String DEFAULT_STYLE = "default";
+    private static final String PARTIAL_NUMBER_PATTERN = "#,##0.00 ";
+
+    @Test
+    public void testToString_US() {
+        AmountNumberToken token = new AmountNumberToken(contextForLocale(US), PARTIAL_NUMBER_PATTERN);
+        assertEquals(token.toString(), "AmountNumberToken [locale=en_US, partialNumberPattern=#,##0.00 ]");
+    }
+
+    private AmountFormatContext contextForLocale(Locale locale) {
+        AmountFormatQuery amountFormatQuery = AmountFormatQueryBuilder.of(locale).set(CODE).build();
+        AmountFormatContextBuilder builder = AmountFormatContextBuilder.of(DEFAULT_STYLE);
+        builder.setLocale(locale);
+        builder.importContext(amountFormatQuery, false);
+        builder.setMonetaryAmountFactory(amountFormatQuery.getMonetaryAmountFactory());
+        AmountFormatContext amountFormatContext = builder.build();
+        return amountFormatContext;
+    }
+}

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/AmountNumberTokenTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/AmountNumberTokenTest.java
@@ -1,8 +1,13 @@
 package org.javamoney.moneta.internal.format;
 
+import org.javamoney.moneta.FastMoney;
 import org.testng.annotations.Test;
 
 import javax.money.format.*;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
 import java.util.Locale;
 
 import static java.util.Locale.*;
@@ -11,21 +16,196 @@ import static org.testng.Assert.*;
 
 public class AmountNumberTokenTest {
     private static final String DEFAULT_STYLE = "default";
-    private static final String PARTIAL_NUMBER_PATTERN = "#,##0.00 ";
+    private static final String PATTERN = "#,##0.00 ";
+
+    @Test
+    public void testParse_throws_exception() {
+        AmountNumberToken token = new AmountNumberToken(contextForLocale(US, null), PATTERN);
+        ParseContext context = new ParseContext("incorrect amount");
+        try {
+            token.parse(context);
+            fail();
+        } catch (MonetaryParseException e) {
+            assertEquals(e.getInput(), "incorrect amount");
+            assertEquals(e.getErrorIndex(), 0);
+            assertEquals(e.getMessage(), "Unparseable number: \"incorrect amount\"");
+        }
+        assertEquals(context.getIndex(), 0);
+        assertFalse(context.isComplete());
+        assertTrue(context.hasError());
+        assertEquals(context.getErrorMessage(), "Unparseable number: \"incorrect amount\"");
+        assertNull(context.getParsedNumber());
+    }
+
+    @Test
+    public void testParse_US() {
+        testParse(US, PATTERN, null, "0", 1, "zero", 0.0, "0");
+        testParse(US, PATTERN, null, "00", 2, "zero dd", 0.0, "00");
+        testParse(US, PATTERN, null, "0.0", 3, "zero d.d", 0.0, "0.0");
+        testParse(US, PATTERN, null, "-0.00", 5, "zero d.dd negative", -0.0, "-0.00");
+        testParse(US, PATTERN, null, "123", 3, "int", 123.0, "123");
+        testParse(US, PATTERN, null, "-123", 4, "int negative", -123.0, "-123");
+        testParse(US, PATTERN, null, "0123", 4, "int padding zero", 123.0, "0123");
+        testParse(US, PATTERN, null, "-0123", 5, "int padding zero negative", -123.0, "-0123");
+        testParse(US, PATTERN, null, "123.4", 5, "float 1", 123.4, "123.4");
+        testParse(US, PATTERN, null, "123.45", 6, "float 2", 123.45, "123.45");
+        testParse(US, PATTERN, null, "123.456", 7, "float 3", 123.456, "123.456");
+        testParse(US, PATTERN, null, "-123.4", 6, "float 1 negative", -123.4, "-123.4");
+        testParse(US, PATTERN, null, "-123.45", 7, "float 2 negative", -123.45, "-123.45");
+        testParse(US, PATTERN, null, "-123.456", 8, "float 3 negative", -123.456, "-123.456");
+        testParse(US, PATTERN, null, "12,345", 6, "int thousands", 12345.0, "12,345");
+        testParse(US, PATTERN, null, "-12,345", 7, "int thousands negative", -12345.0, "-12,345");
+        testParse(US, PATTERN, null, "12,345.6", 8, "float 1 thousands", 12345.6, "12,345.6");
+        testParse(US, PATTERN, null, "12,345.67", 9, "float 2 thousands", 12345.67, "12,345.67");
+        testParse(US, PATTERN, null, "12,345.678", 10, "float 3 thousands", 12345.678, "12,345.678");
+        testParse(US, PATTERN, null, "-12,345.6", 9, "float 1 thousands negative", -12345.6, "-12,345.6");
+        testParse(US, PATTERN, null, "-12,345.67", 10, "float 2 thousands negative", -12345.67, "-12,345.67");
+        testParse(US, PATTERN, null, "-12,345.678", 11, "float 3 thousands negative", -12345.678, "-12,345.678");
+        testParse(US, PATTERN, null, "-1,234,567.89", 13, "float 2 million negative", -1234567.89, "-1,234,567.89");
+    }
+
+    @Test
+    public void testParse_FR() {
+        testParse(FRANCE, PATTERN, null, "0", 1, "zero", 0.0, "0");
+        testParse(FRANCE, PATTERN, null, "00", 2, "zero dd", 0.0, "00");
+        testParse(FRANCE, PATTERN, null, "0,0", 3, "zero d.d", 0.0, "0,0");
+        testParse(FRANCE, PATTERN, null, "-0,00", 5, "zero d.dd negative", -0.0, "-0,00");
+        testParse(FRANCE, PATTERN, null, "123", 3, "int", 123.0, "123");
+        testParse(FRANCE, PATTERN, null, "-123", 4, "int negative", -123.0, "-123");
+        testParse(FRANCE, PATTERN, null, "0123", 4, "int padding zero", 123.0, "0123");
+        testParse(FRANCE, PATTERN, null, "-0123", 5, "int padding zero negative", -123.0, "-0123");
+        testParse(FRANCE, PATTERN, null, "123,4", 5, "float 1", 123.4, "123,4");
+        testParse(FRANCE, PATTERN, null, "123,45", 6, "float 2", 123.45, "123,45");
+        testParse(FRANCE, PATTERN, null, "123,456", 7, "float 3", 123.456, "123,456");
+        testParse(FRANCE, PATTERN, null, "-123,4", 6, "float 1 negative", -123.4, "-123,4");
+        testParse(FRANCE, PATTERN, null, "-123,45", 7, "float 2 negative", -123.45, "-123,45");
+        testParse(FRANCE, PATTERN, null, "-123,456", 8, "float 3 negative", -123.456, "-123,456");
+        testParse(FRANCE, PATTERN, null, "12 345", 6, "int thousands", 12345.0, "12 345");
+        testParse(FRANCE, PATTERN, null, "-12 345", 7, "int thousands negative", -12345.0, "-12 345");
+        testParse(FRANCE, PATTERN, null, "12 345,6", 8, "float 1 thousands", 12345.6, "12 345,6");
+        testParse(FRANCE, PATTERN, null, "12 345,67", 9, "float 2 thousands", 12345.67, "12 345,67");
+        testParse(FRANCE, PATTERN, null, "12 345,678", 10, "float 3 thousands", 12345.678, "12 345,678");
+        testParse(FRANCE, PATTERN, null, "-12 345,6", 9, "float 1 thousands negative", -12345.6, "-12 345,6");
+        testParse(FRANCE, PATTERN, null, "-12 345,67", 10, "float 2 thousands negative", -12345.67, "-12 345,67");
+        testParse(FRANCE, PATTERN, null, "-12 345,678", 11, "float 3 thousands negative", -12345.678, "-12 345,678");
+        testParse(FRANCE, PATTERN, null, "-1 234 567,89", 13, "float 2 million negative", -1234567.89, "-1 234 567,89");
+    }
+
+    @Test
+    public void testParse_FR_with_NBSP() {
+        testParse(FRANCE, PATTERN, null, "12\u00A0345", 6, "int thousands", 12345.0, "12 345");
+        testParse(FRANCE, PATTERN, null, "-12\u00A0345", 7, "int thousands negative", -12345.0, "-12 345");
+        testParse(FRANCE, PATTERN, null, "12\u00A0345,6", 8, "float 1 thousands", 12345.6, "12 345,6");
+        testParse(FRANCE, PATTERN, null, "12\u00A0345,67", 9, "float 2 thousands", 12345.67, "12 345,67");
+        testParse(FRANCE, PATTERN, null, "12\u00A0345,678", 10, "float 3 thousands", 12345.678, "12 345,678");
+        testParse(FRANCE, PATTERN, null, "-12\u00A0345,6", 9, "float 1 thousands negative", -12345.6, "-12 345,6");
+        testParse(FRANCE, PATTERN, null, "-12\u00A0345,67", 10, "float 2 thousands negative", -12345.67, "-12 345,67");
+        testParse(FRANCE, PATTERN, null, "-12\u00A0345,678", 11, "float 3 thousands negative", -12345.678, "-12 345,678");
+        testParse(FRANCE, PATTERN, null, "-1\u00A0234\u00A0567,89", 13, "float 2 million negative", -1234567.89, "-1 234 567,89");
+    }
+
+    @Test
+    public void testParse_FR_with_NBSP_and_preset_decimal_symbols() {
+        DecimalFormat decimalFormat = (DecimalFormat) NumberFormat.getCurrencyInstance(FRANCE);
+        DecimalFormatSymbols syms = decimalFormat.getDecimalFormatSymbols();
+        syms.setGroupingSeparator('\u00A0');
+
+        testParse(FRANCE, PATTERN, syms, "12\u00A0345", 6, "int thousands", 12345.0, "12 345");
+        testParse(FRANCE, PATTERN, syms, "-12\u00A0345", 7, "int thousands negative", -12345.0, "-12 345");
+        testParse(FRANCE, PATTERN, syms, "12\u00A0345,6", 8, "float 1 thousands", 12345.6, "12 345,6");
+        testParse(FRANCE, PATTERN, syms, "12\u00A0345,67", 9, "float 2 thousands", 12345.67, "12 345,67");
+        testParse(FRANCE, PATTERN, syms, "12\u00A0345,678", 10, "float 3 thousands", 12345.678, "12 345,678");
+        testParse(FRANCE, PATTERN, syms, "-12\u00A0345,6", 9, "float 1 thousands negative", -12345.6, "-12 345,6");
+        testParse(FRANCE, PATTERN, syms, "-12\u00A0345,67", 10, "float 2 thousands negative", -12345.67, "-12 345,67");
+        testParse(FRANCE, PATTERN, syms, "-12\u00A0345,678", 11, "float 3 thousands negative", -12345.678, "-12 345,678");
+        testParse(FRANCE, PATTERN, syms, "-1\u00A0234\u00A0567,89", 13, "float 2 million negative", -1234567.89, "-1 234 567,89");
+    }
+
+    @Test
+    public void testParse_CN() {
+        testParse(CHINA, PATTERN, null, "0", 1, "zero", 0.0, "0");
+        testParse(CHINA, PATTERN, null, "00", 2, "zero dd", 0.0, "00");
+        testParse(CHINA, PATTERN, null, "0.0", 3, "zero d.d", 0.0, "0.0");
+        testParse(CHINA, PATTERN, null, "-0.00", 5, "zero d.dd negative", -0.0, "-0.00");
+        testParse(CHINA, PATTERN, null, "123", 3, "int", 123.0, "123");
+        testParse(CHINA, PATTERN, null, "-123", 4, "int negative", -123.0, "-123");
+        testParse(CHINA, PATTERN, null, "0123", 4, "int padding zero", 123.0, "0123");
+        testParse(CHINA, PATTERN, null, "-0123", 5, "int padding zero negative", -123.0, "-0123");
+        testParse(CHINA, PATTERN, null, "123.4", 5, "float 1", 123.4, "123.4");
+        testParse(CHINA, PATTERN, null, "123.45", 6, "float 2", 123.45, "123.45");
+        testParse(CHINA, PATTERN, null, "123.456", 7, "float 3", 123.456, "123.456");
+        testParse(CHINA, PATTERN, null, "-123.4", 6, "float 1 negative", -123.4, "-123.4");
+        testParse(CHINA, PATTERN, null, "-123.45", 7, "float 2 negative", -123.45, "-123.45");
+        testParse(CHINA, PATTERN, null, "-123.456", 8, "float 3 negative", -123.456, "-123.456");
+        testParse(CHINA, PATTERN, null, "12,345", 6, "int thousands", 12345.0, "12,345");
+        testParse(CHINA, PATTERN, null, "-12,345", 7, "int thousands negative", -12345.0, "-12,345");
+        testParse(CHINA, PATTERN, null, "12,345.6", 8, "float 1 thousands", 12345.6, "12,345.6");
+        testParse(CHINA, PATTERN, null, "12,345.67", 9, "float 2 thousands", 12345.67, "12,345.67");
+        testParse(CHINA, PATTERN, null, "12,345.678", 10, "float 3 thousands", 12345.678, "12,345.678");
+        testParse(CHINA, PATTERN, null, "-12,345.6", 9, "float 1 thousands negative", -12345.6, "-12,345.6");
+        testParse(CHINA, PATTERN, null, "-12,345.67", 10, "float 2 thousands negative", -12345.67, "-12,345.67");
+        testParse(CHINA, PATTERN, null, "-12,345.678", 11, "float 3 thousands negative", -12345.678, "-12,345.678");
+        testParse(CHINA, PATTERN, null, "-1,234,567.89", 13, "float 2 million negative", -1234567.89, "-1,234,567.89");
+        testParse(CHINA, PATTERN, null, "-123,4567.89", 12, "grouped by ten thousands", -1234567.89, "-123,4567.89");
+    }
+
+    @Test
+    public void testParse_with_literals_in_patern() {
+        testParse(US, "#,##0.00 ", null, "-123.45", 7, "without literal", -123.45, "-123.45");
+        testParse(US, "BEFORE #,##0.00 ", null, "BEFORE 123.45", 13, "Literal on start", 123.45, "BEFORE 123.45");
+//FIXME        testParse(US, "ONE TWO #,##0.00 ", "ONE TWO -123.45", 7, "Two literals on start", -123.45);
+    }
+
+    @Test
+    public void testPrint_US() throws IOException {
+        AmountNumberToken token = new AmountNumberToken(contextForLocale(US, null), PATTERN);
+        FastMoney amount = FastMoney.of(-42.00,"USD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "-42.00 ");
+    }
 
     @Test
     public void testToString_US() {
-        AmountNumberToken token = new AmountNumberToken(contextForLocale(US), PARTIAL_NUMBER_PATTERN);
+        AmountNumberToken token = new AmountNumberToken(contextForLocale(US, null), PATTERN);
         assertEquals(token.toString(), "AmountNumberToken [locale=en_US, partialNumberPattern=#,##0.00 ]");
     }
 
-    private AmountFormatContext contextForLocale(Locale locale) {
+    private AmountFormatContext contextForLocale(Locale locale, DecimalFormatSymbols syms) {
         AmountFormatQuery amountFormatQuery = AmountFormatQueryBuilder.of(locale).set(CODE).build();
         AmountFormatContextBuilder builder = AmountFormatContextBuilder.of(DEFAULT_STYLE);
         builder.setLocale(locale);
         builder.importContext(amountFormatQuery, false);
         builder.setMonetaryAmountFactory(amountFormatQuery.getMonetaryAmountFactory());
+        if (syms != null) {
+            builder.set(DecimalFormatSymbols.class, syms);
+        }
         AmountFormatContext amountFormatContext = builder.build();
         return amountFormatContext;
+    }
+
+    private void testParse(Locale locale, String pattern, DecimalFormatSymbols syms, String input, int expectedIndex, String comment, double amount, String formatted) {
+        String errorPrefix = "For " + locale + " " + comment + " input \"" + input + "\": ";
+        AmountNumberToken token = new AmountNumberToken(contextForLocale(locale, syms), pattern);
+        ParseContext context = new ParseContext(input);
+        try {
+            token.parse(context);
+        } catch (MonetaryParseException e) {
+            System.err.println(e.getMessage());
+            assertEquals(e.getInput(), input);
+            assertEquals(e.getErrorIndex(), 0);
+
+            assertNull(context.getParsedNumber(), errorPrefix);
+            assertFalse(context.isComplete(), errorPrefix);
+            assertTrue(context.hasError(), errorPrefix);
+            assertEquals(context.getOriginalInput(), input, errorPrefix);
+            fail(errorPrefix + context.getErrorMessage());
+        }
+
+        assertEquals(context.getParsedNumber().doubleValue(), amount, errorPrefix);
+        assertEquals(context.getIndex(), expectedIndex, errorPrefix);
+        assertFalse(context.isComplete(), errorPrefix);
+        assertFalse(context.hasError(), errorPrefix);
+        assertEquals(context.getOriginalInput(), formatted, errorPrefix);
     }
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/CurrencyTokenTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/CurrencyTokenTest.java
@@ -1,0 +1,298 @@
+package org.javamoney.moneta.internal.format;
+
+import org.javamoney.moneta.CurrencyUnitBuilder;
+import org.javamoney.moneta.FastMoney;
+import org.testng.annotations.Test;
+
+import javax.money.CurrencyUnit;
+import javax.money.format.MonetaryParseException;
+import java.io.IOException;
+import java.util.Locale;
+
+import static java.util.Locale.*;
+import static org.javamoney.moneta.format.CurrencyStyle.*;
+import static org.testng.Assert.*;
+
+public class CurrencyTokenTest {
+
+    public static final CurrencyUnit BTC = CurrencyUnitBuilder.of("BTC", "crypto").build();
+
+    @Test
+    public void testParse_CODE() {
+        CurrencyToken token = new CurrencyToken(CODE, FRANCE);
+        ParseContext context = new ParseContext("EUR");
+        token.parse(context);
+        assertEquals(context.getIndex(), 3);
+    }
+
+    @Test
+    public void testParse_CODE_unknown() {
+        CurrencyToken token = new CurrencyToken(CODE, FRANCE);
+        ParseContext context = new ParseContext("BTC");
+        try {
+            token.parse(context);
+        } catch (MonetaryParseException e) {
+            assertEquals(e.getInput(), "BTC");
+            assertEquals(e.getErrorIndex(), -1);
+            assertEquals(e.getMessage(), "Could not parse CurrencyUnit. Unknown currency code: BTC");
+        }
+        assertEquals(context.getIndex(), 0);
+        assertFalse(context.isComplete());
+        assertTrue(context.hasError());
+        assertEquals(context.getErrorMessage(), "Unknown currency code: BTC");
+    }
+
+    @Test
+    public void testParse_SYMBOL_EUR() {
+        CurrencyToken token = new CurrencyToken(SYMBOL, FRANCE);
+        ParseContext context = new ParseContext("€");
+        token.parse(context);
+        assertEquals(context.getIndex(), 1);
+    }
+
+    @Test
+    public void testParse_SYMBOL_GBP() {
+        CurrencyToken token = new CurrencyToken(SYMBOL, FRANCE);
+        ParseContext context = new ParseContext("£");
+        token.parse(context);
+        assertEquals(context.getIndex(), 1);
+    }
+
+    @Test
+    public void testParse_SYMBOL_ambiguous_dollar() {
+        CurrencyToken token = new CurrencyToken(SYMBOL, FRANCE);
+        ParseContext context = new ParseContext("$");
+        try {
+            token.parse(context);
+        } catch (MonetaryParseException e) {
+            assertEquals(e.getInput(), "$");
+            assertEquals(e.getErrorIndex(), -1);
+            assertEquals(e.getMessage(), "$ is not a unique currency symbol.");
+        }
+        assertEquals(context.getIndex(), 0);
+        assertFalse(context.isComplete());
+        assertTrue(context.hasError());
+        assertEquals(context.getErrorMessage(), "$ is not a unique currency symbol.");
+    }
+
+    @Test
+    public void testParse_NUMERIC_CODE() {
+        CurrencyToken token = new CurrencyToken(NUMERIC_CODE, FRANCE);
+        ParseContext context = new ParseContext("840");
+        try {
+            token.parse(context);
+        } catch (MonetaryParseException e) {
+            assertEquals(e.getInput(), "840");
+            assertEquals(e.getErrorIndex(), -1);
+            assertEquals(e.getMessage(), "Could not parse CurrencyUnit. Not yet implemented");
+        }
+        assertEquals(context.getIndex(), 0);
+        assertFalse(context.isComplete());
+        assertTrue(context.hasError());
+        assertEquals(context.getErrorMessage(), "Not yet implemented");
+    }
+
+    @Test
+    public void testParse_NAME() {
+        CurrencyToken token = new CurrencyToken(NAME, FRANCE);
+        ParseContext context = new ParseContext("US Dollar");
+        try {
+            token.parse(context);
+        } catch (MonetaryParseException e) {
+            assertEquals(e.getInput(), "US"); //TODO US Dollar
+            assertEquals(e.getErrorIndex(), -1);
+            assertEquals(e.getMessage(), "Could not parse CurrencyUnit. Not yet implemented");
+        }
+        assertEquals(context.getIndex(), 0);
+        assertFalse(context.isComplete());
+        assertTrue(context.hasError());
+        assertEquals(context.getErrorMessage(), "Not yet implemented");
+    }
+
+    @Test
+    public void testPrint_CODE() throws IOException {
+        CurrencyToken token = new CurrencyToken(CODE, FRANCE);
+        FastMoney amount = FastMoney.of(0, "EUR");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "EUR");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_USD() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, US);
+        FastMoney amount = FastMoney.of(0, "USD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "$");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_USD_for_France() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, FRANCE);
+        FastMoney amount = FastMoney.of(0, "USD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "$US");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_HKD() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, new Locale("en", "HK"));
+        FastMoney amount = FastMoney.of(0, "HKD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "HK$");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_HKD_for_US() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, US);
+        FastMoney amount = FastMoney.of(0, "HKD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "HK$");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_UAH() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, new Locale("uk", "UA"));
+        FastMoney amount = FastMoney.of(0, "UAH");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "₴");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_UAH_for_US() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, US);
+        FastMoney amount = FastMoney.of(0, "UAH");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "UAH");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_RUB() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, new Locale("ru", "RU"));
+        FastMoney amount = FastMoney.of(0, "RUB");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "₽");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_RUB_for_US() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, US);
+        FastMoney amount = FastMoney.of(0, "RUB");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "RUB");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_BGN() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, new Locale("bg", "BG"));
+        FastMoney amount = FastMoney.of(0, "BGN");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+//FIXME        assertEquals(sb.toString(), "лв.");
+        assertEquals(sb.toString(), "лв");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_BGN_for_US() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, US);
+        FastMoney amount = FastMoney.of(0, "BGN");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "BGN");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_EUR() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, FRANCE);
+        FastMoney amount = FastMoney.of(0, "EUR");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "€");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_EUR_for_US() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, US);
+        FastMoney amount = FastMoney.of(0, "EUR");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "€"); // for some reason here is returned a symbol € instead of EUR
+    }
+
+    @Test
+    public void testPrint_SYMBOL_GBP() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, UK);
+        FastMoney amount = FastMoney.of(0, "GBP");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "£");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_GBP_for_France() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, FRANCE);
+        FastMoney amount = FastMoney.of(0, "GBP");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "£GB");
+    }
+
+    @Test
+    public void testPrint_SYMBOL_BTC() throws IOException {
+        CurrencyToken token = new CurrencyToken(SYMBOL, FRANCE);
+        FastMoney amount = FastMoney.of(0, BTC);
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "BTC"); // returned currency code itself
+    }
+
+    @Test
+    public void testPrint_NAME_USD_for_US() throws IOException {
+        CurrencyToken token = new CurrencyToken(NAME, US);
+        FastMoney amount = FastMoney.of(0, "USD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "US Dollar");
+    }
+
+    @Test
+    public void testPrint_NAME_USD_for_FR() throws IOException {
+        CurrencyToken token = new CurrencyToken(NAME, FRANCE);
+        FastMoney amount = FastMoney.of(0, "USD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "dollar des États-Unis");
+    }
+
+    @Test
+    public void testPrint_NAME_BTC() throws IOException {
+        CurrencyToken token = new CurrencyToken(NAME, FRANCE);
+        FastMoney amount = FastMoney.of(0, BTC);
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "BTC"); // returned currency code itself
+    }
+
+    @Test
+    public void testPrint_NUMERIC_CODE() throws IOException {
+        CurrencyToken token = new CurrencyToken(NUMERIC_CODE, FRANCE);
+        FastMoney amount = FastMoney.of(0, "USD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), "840");
+    }
+
+    @Test
+    public void testToString() {
+        CurrencyToken token = new CurrencyToken(CODE, FRANCE);
+        assertEquals(token.toString(), "CurrencyToken [locale=fr_FR, style=CODE]");
+    }
+}

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/LiteralTokenTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/LiteralTokenTest.java
@@ -1,0 +1,55 @@
+package org.javamoney.moneta.internal.format;
+
+import org.javamoney.moneta.FastMoney;
+import org.testng.annotations.Test;
+
+import javax.money.MonetaryAmount;
+import javax.money.MonetaryException;
+import javax.money.format.MonetaryParseException;
+
+import java.io.IOException;
+
+import static org.testng.Assert.*;
+
+public class LiteralTokenTest {
+
+    @Test
+    public void testParse() {
+        LiteralToken token = new LiteralToken(" some text ");
+        ParseContext context = new ParseContext(" some text here");
+        token.parse(context);
+        assertEquals(context.getIndex(), 11);
+    }
+
+    @Test
+    public void testParse_throws_exception() {
+        LiteralToken token = new LiteralToken(" some text ");
+        ParseContext context = new ParseContext("here is some text here");
+        try {
+            token.parse(context);
+        } catch (MonetaryParseException e) {
+            assertEquals(e.getInput(), "here is some text here");
+            assertEquals(e.getErrorIndex(), 0);
+            assertEquals(e.getMessage(), "Parse Error");
+        }
+        assertEquals(context.getIndex(), 0);
+        assertFalse(context.isComplete());
+        assertTrue(context.hasError());
+        assertEquals(context.getErrorMessage(), "Parse Error");
+    }
+
+    @Test
+    public void testPrint() throws IOException {
+        LiteralToken token = new LiteralToken(" some text ");
+        FastMoney amount = FastMoney.of(0,"USD");
+        StringBuilder sb = new StringBuilder();
+        token.print(sb, amount);
+        assertEquals(sb.toString(), " some text ");
+    }
+
+    @Test
+    public void testToString() {
+        LiteralToken token = new LiteralToken(" some text ");
+        assertEquals(token.toString(), "LiteralToken [token= some text ]");
+    }
+}

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/MonetaryAmountFormatTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/MonetaryAmountFormatTest.java
@@ -15,6 +15,8 @@
  */
 package org.javamoney.moneta.internal.format;
 
+import static java.util.Locale.*;
+import static org.javamoney.moneta.format.CurrencyStyle.*;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -24,6 +26,7 @@ import java.util.Locale;
 
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
+import javax.money.format.AmountFormatQuery;
 import javax.money.format.AmountFormatQueryBuilder;
 import javax.money.format.MonetaryAmountFormat;
 import javax.money.format.MonetaryFormats;
@@ -37,27 +40,21 @@ import org.testng.annotations.Test;
  */
 public class MonetaryAmountFormatTest {
 
-
     /**
      * Test method for
      * {@link javax.money.format.MonetaryAmountFormat#format(javax.money.MonetaryAmount)} .
      */
     @Test
     public void testFormat() {
-        MonetaryAmountFormat defaultFormat = MonetaryFormats.getAmountFormat(Locale.GERMANY);
-        assertEquals("12,50 CHF", defaultFormat
-                .format(Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(12.50)
-                        .create()));
-        assertEquals("123.456.789.101.112,12 INR", defaultFormat
-                .format(Monetary.getDefaultAmountFactory().setCurrency("INR")
-                        .setNumber(123456789101112.123456).create()));
+        MonetaryAmountFormat defaultFormat = MonetaryFormats.getAmountFormat(GERMANY);
+        MonetaryAmount amountChf1 = Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(12.50).create();
+        assertEquals("12,50 CHF", defaultFormat.format(amountChf1));
+        MonetaryAmount amountInr = Monetary.getDefaultAmountFactory().setCurrency("INR").setNumber(123456789101112.123456).create();
+        assertEquals("123.456.789.101.112,12 INR", defaultFormat.format(amountInr));
         defaultFormat = MonetaryFormats.getAmountFormat(new Locale("", "IN"));
-        assertEquals("CHF 1,211,112.50", defaultFormat
-                .format(Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(1211112.50)
-                        .create()));
-        assertEquals("INR 123,456,789,101,112.12", defaultFormat
-                .format(Monetary.getDefaultAmountFactory().setCurrency("INR")
-                        .setNumber(123456789101112.123456).create()));
+        MonetaryAmount amountChf = Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(1211112.50).create();
+        assertEquals("CHF 1,211,112.50", defaultFormat.format(amountChf));
+        assertEquals("INR 123,456,789,101,112.12", defaultFormat.format(amountInr));
         // Locale india = new Locale("", "IN");
         // defaultFormat = MonetaryFormats.getAmountFormatBuilder(india)
         // .setNumberGroupSizes(3, 2).of();
@@ -72,11 +69,10 @@ public class MonetaryAmountFormatTest {
      */
     @Test
     public void testFormatWithBuilder() {
-        MonetaryAmountFormat defaultFormat =
-                MonetaryFormats.getAmountFormat(AmountFormatQueryBuilder.of(Locale.JAPANESE).build());
-        assertEquals("CHF12.50", defaultFormat
-                .format(Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(12.50)
-                        .create()));
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(JAPANESE).build();
+        MonetaryAmountFormat defaultFormat = MonetaryFormats.getAmountFormat(formatQuery);
+        MonetaryAmount amountChf = Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(12.50).create();
+        assertEquals("CHF12.50", defaultFormat.format(amountChf));
     }
 
     /**
@@ -85,28 +81,23 @@ public class MonetaryAmountFormatTest {
      */
     @Test
     public void testFormatWithBuilder2() {
-        MonetaryAmountFormat format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(Locale.GERMANY).set(CurrencyStyle.NUMERIC_CODE).build());
-        assertEquals("12,50 756", format.format(
-                Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(12.50).create()));
-        format = MonetaryFormats
-                .getAmountFormat(AmountFormatQueryBuilder.of(Locale.US).set(CurrencyStyle.SYMBOL).build());
-        assertEquals("$123,456.56", format.format(
-                Monetary.getDefaultAmountFactory().setCurrency("USD").setNumber(123456.561)
-                        .create()));
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(GERMANY).set(NUMERIC_CODE).build();
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(formatQuery);
+        MonetaryAmount amountChf = Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(12.50).create();
+        assertEquals("12,50 756", format.format(amountChf));
+        format = MonetaryFormats.getAmountFormat(AmountFormatQueryBuilder.of(US).set(SYMBOL).build());
+        MonetaryAmount amountUsd = Monetary.getDefaultAmountFactory().setCurrency("USD").setNumber(123456.561).create();
+        assertEquals("$123,456.56", format.format(amountUsd));
     }
 
     /**
      * Test method for
      * {@link javax.money.format.MonetaryAmountFormat#print(java.lang.Appendable, javax.money.MonetaryAmount)}
-     * .
-     *
-     * @throws IOException
      */
     @Test
     public void testPrint() throws IOException {
         StringBuilder b = new StringBuilder();
-        MonetaryAmountFormat defaultFormat = MonetaryFormats.getAmountFormat(Locale.GERMANY);
+        MonetaryAmountFormat defaultFormat = MonetaryFormats.getAmountFormat(GERMANY);
         defaultFormat.print(b, Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(12.50).create());
         assertEquals("12,50 CHF", b.toString());
         b.setLength(0);
@@ -134,58 +125,86 @@ public class MonetaryAmountFormatTest {
 
     /**
      * Test method for {@link javax.money.format.MonetaryAmountFormat#parse(java.lang.CharSequence)}
-     * .
-     *
-     * @throws ParseException
      */
     @Test
     public void testParse() throws ParseException {
-        MonetaryAmountFormat defaultFormat = MonetaryFormats.getAmountFormat(Locale.GERMANY);
-        assertEquals(Monetary.getDefaultAmountFactory().setCurrency("EUR").setNumber(new BigDecimal("12.50"))
-                .create(), defaultFormat.parse("12,50 EUR"));
-        assertEquals(Monetary.getDefaultAmountFactory().setCurrency("EUR").setNumber(new BigDecimal("12.50"))
-                .create(), defaultFormat.parse("  \t 12,50 EUR"));
-        assertEquals(Monetary.getDefaultAmountFactory().setCurrency("EUR").setNumber(new BigDecimal("12.50"))
-                .create(), defaultFormat.parse("  \t 12,50 \t\n EUR  \t\n\n "));
-        assertEquals(Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(new BigDecimal("12.50"))
-                .create(), defaultFormat.parse("12,50 CHF"));
+        MonetaryAmountFormat defaultFormat = MonetaryFormats.getAmountFormat(GERMANY);
+        MonetaryAmount amountEur = Monetary.getDefaultAmountFactory().setCurrency("EUR").setNumber(new BigDecimal("12.50")).create();
+        MonetaryAmount amountChf = Monetary.getDefaultAmountFactory().setCurrency("CHF").setNumber(new BigDecimal("12.50")).create();
+        assertEquals(amountEur, defaultFormat.parse("12,50 EUR"));
+        assertEquals(amountEur, defaultFormat.parse("\u00A0 \u202F \u2007 12,50 EUR"));
+        assertEquals(amountEur, defaultFormat.parse("\u00A0 \u202F \u2007 12,50 \u00A0 \u202F \u2007 EUR  \t\n\n "));
+        assertEquals(amountChf, defaultFormat.parse("12,50 CHF"));
     }
 
+    @Test
+    public void testWithCustomPatternAndRounding() {
+        Money money = Money.of(12345.23456789, "EUR");
+        // format with 5 digits after comma: note that formatted value was rounded to 5 digits
+        testCustomFormat(money, "#,##0.00### ¤", "12.345,23456789 €", "12.345,23457 €", SYMBOL);
+        // the same format but with currency symbol on start
+        testCustomFormat(money, "¤ #,##0.00###", "€ 12.345,23456789", "€ 12.345,23457", SYMBOL);
+    }
 
-    /**
-     * Test related to {@link https://java.net/jira/browse/JAVAMONEY-92}.
-     */
     @Test
     public void testWithCustomPattern() {
-        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(
-                AmountFormatQueryBuilder.of(Locale.GERMANY)
-                        .set(CurrencyStyle.SYMBOL)
-                        .set("pattern", "#,##0.00### ¤")
-                        .build());
-        Money money = Money.of(12345.23456789, "EUR");
-        assertEquals("12.345,23457 €", format.format(money));
-
-        format = MonetaryFormats.getAmountFormat(
-                AmountFormatQueryBuilder.of(Locale.GERMANY)
-                        .set(CurrencyStyle.SYMBOL)
-                        .build());
-        assertEquals("12.345,23 €", format.format(money));
+        Money money = Money.of(12345.23, "EUR");
+        testCustomFormat(money, "#,##0.## ¤", "12.345,23 EUR", "12.345,23 EUR", CODE);
+        testCustomFormat(money, "#,##0.##¤", "12.345,23EUR", "12.345,23EUR", CODE);
+        testCustomFormat(money, "¤ #,##0.##", "EUR 12.345,23", "EUR 12.345,23", CODE);
+        testCustomFormat(money, "¤#,##0.##", "EUR12.345,23", "EUR12.345,23", CODE);
+        testCustomFormat(money, "LITERAL ¤#,##0.##", "LITERAL EUR12.345,23", "LITERAL EUR12.345,23", CODE);
+        testCustomFormat(money, "LITERAL ¤ #,##0.##", "LITERAL EUR 12.345,23", "LITERAL EUR 12.345,23", CODE);
+        testCustomFormat(money, "LITERAL ¤ #,##0.## LITERAL", "LITERAL EUR 12.345,23 LITERAL", "LITERAL EUR 12.345,23 LITERAL", CODE);
+        testCustomFormat(money, "LITERAL #,##0.## ¤ LITERAL", "LITERAL 12.345,23 EUR LITERAL", "LITERAL 12.345,23 EUR LITERAL", CODE);
+        testCustomFormat(money, "LITERAL #,##0.##¤ LITERAL", "LITERAL 12.345,23EUR LITERAL", "LITERAL 12.345,23EUR LITERAL", CODE);
     }
 
-    /**
-     * Test related to {@link https://java.net/jira/browse/JAVAMONEY-151}.
-     */
+    @Test
+    public void testWithCustomPatternForNegativeAmount() {
+        Money moneyNegative = Money.of(-12345.23, "EUR");
+        testCustomFormat(moneyNegative, "#,##0.## ¤", "-12.345,23 EUR", "-12.345,23 EUR", CODE);
+        testCustomFormat(moneyNegative, "#,##0.##¤", "-12.345,23EUR", "-12.345,23EUR", CODE);
+//FIXME        testCustomFormat(moneyNegative, "¤ #,##0.##", "EUR -12.345,23", "EUR -12.345,23", CODE);
+        testCustomFormat(moneyNegative, "¤#,##0.##", "EUR-12.345,23", "EUR-12.345,23", CODE);
+        testCustomFormat(moneyNegative, "LITERAL ¤#,##0.##", "LITERAL EUR-12.345,23", "LITERAL EUR-12.345,23", CODE);
+//FIXME        testCustomFormat(moneyNegative, "LITERAL ¤ #,##0.##", "LITERAL EUR -12.345,23", "LITERAL EUR -12.345,23", CODE);
+//FIXME        testCustomFormat(moneyNegative, "LITERAL ¤ #,##0.## LITERAL", "LITERAL EUR -12.345,23 LITERAL", "LITERAL EUR -12.345,23 LITERAL", CODE);
+//FIXME        testCustomFormat(moneyNegative, "LITERAL #,##0.## ¤ LITERAL", "LITERAL -12.345,23 EUR LITERAL", "LITERAL -12.345,23 EUR LITERAL", CODE);
+//FIXME        testCustomFormat(moneyNegative, "LITERAL #,##0.##¤ LITERAL", "LITERAL -12.345,23EUR LITERAL", "LITERAL -12.345,23EUR LITERAL", CODE);
+    }
+
+    @Test
+    public void testWithTwoCustomPatterns() {
+        Money money = Money.of(12345.23, "EUR");
+        Money moneyNegative = Money.of(-12345.23, "EUR");
+        testCustomFormat(money, "#,##0.## ¤;#,##0.## ¤", "12.345,23 EUR", "12.345,23 EUR", CODE);
+        testCustomFormat(moneyNegative, "#,##0.## ¤;#,##0.## ¤", "-12.345,23 EUR", "-12.345,23 EUR", CODE);
+    }
+
+    private void testCustomFormat(Money money, String pattern, String input, String expectedFormatted, CurrencyStyle style) {
+        MonetaryAmountFormat formatWithLiteralOnStart = formatWithCustomPattern(pattern, style);
+        assertEquals(formatWithLiteralOnStart.format(money), expectedFormatted);
+        assertEquals(formatWithLiteralOnStart.parse(input), money);
+    }
+
+    private MonetaryAmountFormat formatWithCustomPattern(String pattern, CurrencyStyle code) {
+        AmountFormatQuery formatQuery = AmountFormatQueryBuilder.of(GERMANY).set(code).set("pattern", pattern).build();
+        return MonetaryFormats.getAmountFormat(formatQuery);
+    }
+
     @Test
     public void testBulgarianLev(){
         MonetaryAmount money = Money.of(1123000.50, "BGN");
-        Locale locale = new Locale("", "BG");
+        Locale locale = new Locale("bg", "BG");
         MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(
-                AmountFormatQueryBuilder.of(locale).set(CurrencyStyle.SYMBOL)
+                AmountFormatQueryBuilder.of(locale).set(SYMBOL)
                         .build());
         assertEquals(format.format(money), "1 123 000,50 лв");
+//FIXME        assertEquals(format.format(money), "1 123 000,50 лв.");
 
         format = MonetaryFormats.getAmountFormat(
-                AmountFormatQueryBuilder.of(locale).set(CurrencyStyle.CODE)
+                AmountFormatQueryBuilder.of(locale).set(CODE)
                         .build());
         assertEquals(format.format(money), "1 123 000,50 BGN");
     }

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/ParseContextTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/ParseContextTest.java
@@ -1,0 +1,52 @@
+package org.javamoney.moneta.internal.format;
+
+import org.javamoney.moneta.CurrencyUnitBuilder;
+import org.testng.annotations.Test;
+
+import javax.money.CurrencyUnit;
+
+import static org.testng.Assert.*;
+
+public class ParseContextTest {
+    public static final CurrencyUnit EUR = CurrencyUnitBuilder.of("EUR", "test").build();
+
+    @Test
+    public void testSkip() {
+        ParseContext context = new ParseContext(" EUR");
+        context.skipWhitespace();
+        assertEquals(context.getIndex(), 1);
+    }
+
+    @Test
+    public void testReset() {
+        ParseContext context = new ParseContext(" EUR");
+        context.skipWhitespace();
+        assertEquals(context.getIndex(), 1);
+        context.setError();
+        context.setErrorIndex(2);
+        context.setErrorMessage("Error");
+        context.setParsedNumber(25);
+        context.setParsedCurrency(EUR);
+        context.reset();
+        assertEquals(context.getOriginalInput(), " EUR");
+        assertEquals(context.getIndex(), 0);
+        assertEquals(context.getErrorIndex(), -1);
+        assertNull(context.getParsedNumber());
+        assertNull(context.getParsedCurrency());
+        assertNull(context.getErrorMessage());
+    }
+
+    @Test
+    public void testToString() {
+        ParseContext context = new ParseContext(" EUR");
+        context.skipWhitespace();
+        assertEquals(context.getIndex(), 1);
+        context.setError();
+        context.setErrorIndex(2);
+        context.setErrorMessage("Error");
+        context.setParsedNumber(25);
+        context.setParsedCurrency(EUR);
+        assertEquals(context.toString(), "ParseContext [index=1, errorIndex=2, originalInput=' EUR', parsedNumber=25', parsedCurrency=BuildableCurrencyUnit(currencyCode=EUR, numericCode=-1, defaultFractionDigits=2, context=CurrencyContext (\n" +
+                "{provider=test}))]");
+    }
+}

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/ParseContextTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/ParseContextTest.java
@@ -12,9 +12,9 @@ public class ParseContextTest {
 
     @Test
     public void testSkip() {
-        ParseContext context = new ParseContext(" EUR");
+        ParseContext context = new ParseContext(" \u00A0 \u202F \u2007 \u2060 EUR");
         context.skipWhitespace();
-        assertEquals(context.getIndex(), 1);
+        assertEquals(context.getIndex(), " \u00A0 \u202F \u2007 ".length());
     }
 
     @Test

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/DefaultNumberValueTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/DefaultNumberValueTest.java
@@ -24,7 +24,7 @@ import javax.money.NumberValue;
 
 import org.testng.annotations.Test;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 public class DefaultNumberValueTest {
 

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/MoneyUtilsTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/MoneyUtilsTest.java
@@ -1,0 +1,55 @@
+package org.javamoney.moneta.spi;
+
+import org.javamoney.moneta.FastMoney;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.money.CurrencyUnit;
+import javax.money.Monetary;
+import javax.money.MonetaryException;
+import java.math.BigDecimal;
+
+import static java.math.BigDecimal.TEN;
+import static org.javamoney.moneta.spi.MoneyUtils.*;
+import static org.testng.Assert.*;
+
+public class MoneyUtilsTest {
+
+    @Test
+    public void testGetBigDecimal_long() {
+        assertEquals(getBigDecimal(10), TEN);
+    }
+
+    @Test
+    public void testGetBigDecimal_double() {
+        expectThrows(ArithmeticException.class, () -> getBigDecimal(Double.NaN));
+        expectThrows(ArithmeticException.class, () -> getBigDecimal(Double.POSITIVE_INFINITY));
+        expectThrows(ArithmeticException.class, () -> getBigDecimal(Double.NEGATIVE_INFINITY));
+        assertEquals(getBigDecimal(0.24D), new BigDecimal("0.24"));
+        assertEquals(getBigDecimal(0.25F), new BigDecimal("0.25"));
+    }
+
+    @Test
+    public void testGetBigDecimal_Number() {
+        expectThrows(ArithmeticException.class, () -> getBigDecimal(Float.valueOf(Float.NaN)));
+        expectThrows(ArithmeticException.class, () -> getBigDecimal(Float.valueOf(Float.POSITIVE_INFINITY)));
+        expectThrows(ArithmeticException.class, () -> getBigDecimal(Float.valueOf(Float.NEGATIVE_INFINITY)));
+        assertEquals(getBigDecimal(Byte.valueOf((byte) 10)), TEN);
+        assertEquals(getBigDecimal(Short.valueOf((short) 10)), TEN);
+        assertEquals(getBigDecimal(Float.valueOf(0.24F)), new BigDecimal("0.24"));
+    }
+
+    @Test
+    public void testCheckAmountParameter() {
+        CurrencyUnit dollar = Monetary.getCurrency("USD");
+        CurrencyUnit real = Monetary.getCurrency("BRL");
+        checkAmountParameter(FastMoney.of(0, "USD"), dollar);
+        expectThrows(MonetaryException.class, () -> checkAmountParameter(FastMoney.of(0, "USD"), real));
+    }
+
+    @Test
+    public void testReplaceNbspWithSpace() {
+        assertEquals(replaceNbspWithSpace("14\u00A0000,12\u00A0EUR"), "14 000,12 EUR");
+    }
+
+}

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/MoneyUtilsTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/MoneyUtilsTest.java
@@ -1,7 +1,6 @@
 package org.javamoney.moneta.spi;
 
 import org.javamoney.moneta.FastMoney;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.money.CurrencyUnit;
@@ -49,7 +48,7 @@ public class MoneyUtilsTest {
 
     @Test
     public void testReplaceNbspWithSpace() {
-        assertEquals(replaceNbspWithSpace("14\u00A0000,12\u00A0EUR"), "14 000,12 EUR");
+        assertEquals(replaceNbspWithSpace("14\u202F000,12\u00A0EUR"), "14 000,12 EUR");
     }
 
 }


### PR DESCRIPTION
This PR is fixes #193 #210 #202 and related to #151 
Please let's discuss everything in scope of #193 

The PR is not fully backward compatible - after the change c5a49ac33844d62c41e926a0e1164dd406b6057f  if parsed input string contains tab `\t` then previously this will be just trimmed but now it will fail. But normally this should not affect anyone.

Note that there is still some bugs which are mostly covered with a unit test assertions that are commented with `//FIXME` 

For example amounts with minus sign may be improperly parsed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/278)
<!-- Reviewable:end -->
