### PR TITLE
#283 fix a bug when all numbers was rescaled to max scale

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/AbstractRateProvider.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/AbstractRateProvider.java
@@ -145,18 +145,16 @@ public abstract class AbstractRateProvider implements ExchangeRateProvider {
     }
 
     protected int getScale(String key) {
-		String string = MonetaryConfig.getConfig().getOrDefault(
-				key, "-1");
-		if (string.isEmpty()) {
-			return -1;
-		} else {
-			try {
-				return Integer.valueOf(string);
-			} catch (NumberFormatException e) {
-				return -1;
-			}
-		}
-	}
+        String string = MonetaryConfig.getConfig().get(key);
+        if (string == null || string.isEmpty()) {
+            return -1;
+        }
+        try {
+            return Integer.parseInt(string);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
 
     protected ConversionContext getExchangeContext(String key) {
 		int scale = getScale(key);

--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/MoneyUtils.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/MoneyUtils.java
@@ -103,11 +103,14 @@ public final class MoneyUtils {
         if (Objects.nonNull(moneyContext)) {
             MathContext mc = getMathContext(moneyContext, HALF_EVEN);
             bd = new BigDecimal(bd.toString(), mc);
-            if (moneyContext.getMaxScale() > 0) {
-                if (LOG.isLoggable(FINEST)) {
-                    LOG.log(FINEST, "Got Max Scale %n", moneyContext.getMaxScale());
+            int maxScale = moneyContext.getMaxScale();
+            if (maxScale > 0) {
+                if (bd.scale() > maxScale) {
+                    if (LOG.isLoggable(FINEST)) {
+                        LOG.log(FINEST, "The number scale is " + bd.scale() + " but Max Scale is " + maxScale);
+                    }
+                    bd = bd.setScale(maxScale, mc.getRoundingMode());
                 }
-                bd = bd.setScale(moneyContext.getMaxScale(), mc.getRoundingMode());
             }
         }
         return bd;

--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormatTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/format/DefaultMonetaryAmountFormatTest.java
@@ -64,9 +64,7 @@ public class DefaultMonetaryAmountFormatTest {
         MonetaryAmount parsedAmount = format.parse("USD1,000.42");
         assertEquals(parsedAmount.getCurrency().getCurrencyCode(), "USD");
         assertEquals(parsedAmount.getNumber().doubleValueExact(), 1000.42D);
-//FIXME        assertEquals(parsedAmount.toString(), "USD 1000.42");
-        // see https://github.com/JavaMoney/jsr354-ri/issues/283
-        assertEquals(parsedAmount.toString(), "USD 1000.420000000000000000000000000000000000000000000000000000000000000");
+        assertEquals(parsedAmount.toString(), "USD 1000.42");
     }
 
     @Test
@@ -78,9 +76,7 @@ public class DefaultMonetaryAmountFormatTest {
         MonetaryAmount parsedAmount = format.parse("0.01 USD");
         assertEquals(parsedAmount.getCurrency().getCurrencyCode(), "USD");
         assertEquals(parsedAmount.getNumber().doubleValueExact(), 0.01D);
-//FIXME        assertEquals(parsedAmount.toString(), "USD 0.01");
-        // see https://github.com/JavaMoney/jsr354-ri/issues/283
-        assertEquals(parsedAmount.toString(), "USD 0.010000000000000000000000000000000000000000000000000000000000000");
+        assertEquals(parsedAmount.toString(), "USD 0.01");
     }
 
     @Test


### PR DESCRIPTION
This needs for a review from @atsticks so Anatole please take a look.
If I understood the logic of  the MoneyUtils.getBigDecimal correctly form this test case:

	@Test
	public void shouldUseContextInFactory() {
		MonetaryContext mc = MonetaryContextBuilder.of().setMaxScale(2).setPrecision(64).set(RoundingMode.FLOOR).build();
		MonetaryAmount am = Monetary.getDefaultAmountFactory().setContext(mc).setNumber(999.999).setCurrency("EUR").create();
		BigDecimal numberValue = am.getNumber().numberValue(BigDecimal.class);
		assertEquals(numberValue, BigDecimal.valueOf(999.99));
	}


Then the method should round a number to max scale if it doesn’t fit.
So for a FastMoney max scale is 5 but for a Money it’s 63.

I’ll create some unit test in MoneyUtilsTest to cover this better if my assumption is right and you confirm it.
Also please note that I changed the logging message because it used incorrect placeholder %n while for decimals it should be %d. But even this not working because I guess that logger doesn’t accept placeholders. Even more: it looks like the logger initiated as a static field doesn’t work. Will investigate that later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/290)
<!-- Reviewable:end -->
