### PR TITLE
CCUP search by numeric currency code

### DIFF
--- a/moneta-core/src/test/java/org/javamoney/moneta/internal/ConfigurableCurrencyUnitProviderTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/internal/ConfigurableCurrencyUnitProviderTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2012, 2014, Credit Suisse (Anatole Tresch), Werner Keil and others by the @author tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.javamoney.moneta.internal;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.money.CurrencyQuery;
+import javax.money.CurrencyQueryBuilder;
+import javax.money.CurrencyUnit;
+import javax.money.Monetary;
+
+import org.javamoney.moneta.CurrencyUnitBuilder;
+import org.testng.annotations.Test;
+
+/**
+ * @author Philippe Marschall
+ */
+public class ConfigurableCurrencyUnitProviderTest {
+    
+    /**
+     * Tests that searching by numeric code is supported by {@link ConfigurableCurrencyUnitProvider}.
+     */
+    @Test
+    public void testSearchByNumericCurrencyCode() {
+        CurrencyUnit usd = CurrencyUnitBuilder.of("USD", "search-test")
+                        .setNumericCode(840)
+                        .setDefaultFractionDigits(2)
+                        .build(false);
+        CurrencyUnit eur = CurrencyUnitBuilder.of("EUR", "search-test")
+                        .setNumericCode(978)
+                        .setDefaultFractionDigits(2)
+                        .build(false);
+        
+        ConfigurableCurrencyUnitProvider.registerCurrencyUnit(usd);
+        ConfigurableCurrencyUnitProvider.registerCurrencyUnit(eur);
+        try {
+            CurrencyQuery query = CurrencyQueryBuilder.of()
+                .setProviderName(ConfigurableCurrencyUnitProvider.class.getSimpleName())
+                .setNumericCodes(840)
+                .build();
+            CurrencyUnit currency = Monetary.getCurrency(query);
+            assertEquals(usd, currency);
+        } finally {
+            ConfigurableCurrencyUnitProvider.removeCurrencyUnit(usd.getCurrencyCode());
+            ConfigurableCurrencyUnitProvider.removeCurrencyUnit(eur.getCurrencyCode());
+        }
+    }
+}


### PR DESCRIPTION
Add support for searching by numeric currency code to
ConfigurableCurrencyUnitProvider.

Extend the current register* and remove* methods to handle a numeric
currency code if present.

This fixes #308

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/310)
<!-- Reviewable:end -->
