### PR TITLE
Optimize isCurrencyAvailable

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/DefaultMonetaryCurrenciesSingletonSpi.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/DefaultMonetaryCurrenciesSingletonSpi.java
@@ -15,6 +15,7 @@ package org.javamoney.moneta.internal;
 import org.javamoney.moneta.spi.MonetaryConfig;
 
 import javax.money.CurrencyQuery;
+import javax.money.CurrencyQueryBuilder;
 import javax.money.CurrencyUnit;
 import javax.money.spi.Bootstrap;
 import javax.money.spi.CurrencyProviderSpi;
@@ -22,6 +23,7 @@ import javax.money.spi.MonetaryCurrenciesSingletonSpi;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,6 +52,25 @@ public class DefaultMonetaryCurrenciesSingletonSpi implements MonetaryCurrencies
             }
         }
         return result;
+    }
+
+    @Override
+    public boolean isCurrencyAvailable(String code, String... providers) {
+        return isCurrencyAvailable(CurrencyQueryBuilder.of().setCurrencyCodes(code).setProviderNames(providers).build());
+    }
+
+    @Override
+    public boolean isCurrencyAvailable(Locale locale, String... providers) {
+        return isCurrencyAvailable(CurrencyQueryBuilder.of().setCountries(locale).setProviderNames(providers).build());
+    }
+
+    private boolean isCurrencyAvailable(CurrencyQuery query) {
+        for (CurrencyProviderSpi provider : collectProviders(query)) {
+            if (provider.isCurrencyAvailable(query)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private List<CurrencyProviderSpi> collectProviders(CurrencyQuery query) {


### PR DESCRIPTION
Optimize DefaultMonetaryCurrenciesSingletonSpi#isCurrencyAvailable by
delegating to CurrencyProviderSpi.

DefaultMonetaryCurrenciesSingletonSpi#isCurrencyAvailable currently
searches for the currencies in the providers. This is not optimal for
two reasons:

* if one provider returns a single currency the return a currency the
  return value will be true and there is no need to search for other
  currencies or check other providers

* the currency provider already offers a #isCurrencyAvailable method
  which is potentially more efficient

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/311)
<!-- Reviewable:end -->
