### PR TITLE
JDKCurrencyAdapter hashCode prevents interoperable implementations

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/BuildableCurrencyUnit.java
@@ -109,7 +109,7 @@ final class BuildableCurrencyUnit implements CurrencyUnit,
 	 */
 	@Override
 	public int hashCode() {
-		return Objects.hashCode(currencyCode);
+		return currencyCode.hashCode();
 	}
 
 	/*
@@ -124,7 +124,7 @@ final class BuildableCurrencyUnit implements CurrencyUnit,
 		}
 		if (obj instanceof CurrencyUnit) {
 			CurrencyUnit other = (CurrencyUnit) obj;
-			return Objects.equals(getCurrencyCode(), other.getCurrencyCode());
+			return getCurrencyCode().equals(other.getCurrencyCode());
 		}
 		return false;
 	}

--- a/moneta-core/src/main/java/org/javamoney/moneta/internal/JDKCurrencyAdapter.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/internal/JDKCurrencyAdapter.java
@@ -134,7 +134,7 @@ public final class JDKCurrencyAdapter implements CurrencyUnit, Serializable, Com
      */
     @Override
     public int hashCode() {
-        return Objects.hashCode(baseCurrency);
+        return baseCurrency.getCurrencyCode().hashCode();
     }
 
     /*
@@ -149,7 +149,7 @@ public final class JDKCurrencyAdapter implements CurrencyUnit, Serializable, Com
         }
         if (obj instanceof CurrencyUnit) {
             CurrencyUnit other = (CurrencyUnit) obj;
-            return Objects.equals(getCurrencyCode(), other.getCurrencyCode());
+            return getCurrencyCode().equals(other.getCurrencyCode());
         }
         return false;
     }

--- a/moneta-core/src/test/java/org/javamoney/moneta/CurrenciesTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/CurrenciesTest.java
@@ -16,7 +16,9 @@
 package org.javamoney.moneta;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -128,6 +130,27 @@ public class CurrenciesTest {
 		assertTrue(0 > cur2.compareTo(cur1));
 		assertEquals(0, cur1.compareTo(cur1));
 		assertEquals(0, cur2.compareTo(cur2));
+	}
+	
+	/**
+	 * Test equals and hashCode methods for
+	 * {@link javax.money.CurrencyUnit}s.
+	 */
+	@Test
+	public void testEqualsHashCode() {
+		String currencyCode = "USD";
+		CurrencyUnit cur1 = Monetary.getCurrency(currencyCode, "default");
+		CurrencyUnit cur2 = CurrencyUnitBuilder.of(currencyCode, "equals-hashCode-test")
+                .setDefaultFractionDigits(2)
+                .build(false);
+
+		assertNotSame(cur1, cur2);
+		assertNotEquals(cur1.getContext().getProviderName(), cur2.getContext().getProviderName());
+		assertEquals(cur1, cur2);
+		assertEquals(cur2, cur1);
+		assertEquals(cur1.hashCode(), cur2.hashCode());
+		assertEquals(cur1.hashCode(), currencyCode.hashCode());
+		assertEquals(cur2.hashCode(), currencyCode.hashCode());
 	}
 
 	/**


### PR DESCRIPTION
CurrencyUnit defines equality in terms of #getCurrencyCode() and
JDKCurrencyAdapter#equals follows this specification. However
JDKCurrencyAdapter#hashCode does not and uses JDK Currency #hashCode
which uses #hashCode from Object which makes it impossible to implement
a currency that is equal to JDKCurrencyAdapter and has the same

Also there were same unnecessary null checks in hashCode and equals
methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/314)
<!-- Reviewable:end -->
