### PR TITLE
Use default money context if context is not specified.

### DIFF
--- a/moneta-core/src/main/java/org/javamoney/moneta/Money.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/Money.java
@@ -119,7 +119,7 @@ public final class Money implements MonetaryAmount, Comparable<MonetaryAmount>, 
             this.monetaryContext = DEFAULT_MONETARY_CONTEXT;
         }
         Objects.requireNonNull(number, "Number is required.");
-        this.number = MoneyUtils.getBigDecimal(number, monetaryContext);
+        this.number = MoneyUtils.getBigDecimal(number, this.monetaryContext);
     }
 
     /**


### PR DESCRIPTION
Creation of Money thru static factory Money.of is ignoring default money context

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-ri/334)
<!-- Reviewable:end -->
