### PR TITLE
Fix Swiss Francs cash rounding example in user guide

### DIFF
--- a/moneta-core/src/main/asciidoc/userguide.adoc
+++ b/moneta-core/src/main/asciidoc/userguide.adoc
@@ -552,13 +552,13 @@ MonetaryAmount roundedAmount = amt.with(rounding); // uses Monetary.getRounding(
 
 For Swiss Francs also a corresponding cash rounding is accessible. In Switzerland the smallest minor in cash are
 5 Rappen, so everything must be rounded to minors dividable by 5. This rounding can be accessed by setting the
-+cashRounding=tru+ property, when accessing a currency rounding for CHF:
++cashRounding=true+ property, when accessing a currency rounding for CHF:
 
 [source,java]
 .Access Swiss Francs Cash Rounding
 --------------------------------------------
-MonetaryRounding rounding = Monetary.getRounding(Monetary.getCurrency("CHF"),
-  RoundingQueryBuilder.of().set("cashRounding", true).build()
+MonetaryRounding rounding = Monetary.getRounding(
+  RoundingQueryBuilder.of().setCurrency(Monetary.getCurrency("CHF")).set("cashRounding", true).build()
 );
 MonetaryAmount amt = ...;
 MonetaryAmount roundedAmount = amt.with(rounding); // amount rounded in CHF cash rounding


### PR DESCRIPTION
This PR updates the Swiss Francs cash rounding example in `userguide.adoc` to correct the use of the `getRounding` method. The previous example incorrectly passed both a `CurrencyUnit` and a `RoundingQuery` to `Monetary.getRounding()`, which is not supported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/JavaMoney/jsr354-ri/418)
<!-- Reviewable:end -->
