### PR TITLE
Add retry mechanism to `CompoundRateProvider.getExchangeRate` on failure

### DIFF
--- a/moneta-core/pom.xml
+++ b/moneta-core/pom.xml
@@ -217,6 +217,13 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.javamoney</groupId>
+			<artifactId>moneta</artifactId>
+			<version>1.4.4</version>
+			<type>pom</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.money</groupId>
 			<artifactId>money-api</artifactId>
 			<version>${jsr.version}</version>

--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/CompoundRateProvider.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/CompoundRateProvider.java
@@ -105,7 +105,7 @@ public class CompoundRateProvider extends AbstractRateProvider {
      */
     @Override
     public ExchangeRate getExchangeRate(ConversionQuery conversionQuery) {
-        return getExchangeRate(conversionQuery, false);
+        return getExchangeRate(conversionQuery, true);
     }
 
     public ExchangeRate getExchangeRate(ConversionQuery conversionQuery, boolean failFast) {

--- a/moneta-core/src/main/java/org/javamoney/moneta/spi/CompoundRateProvider.java
+++ b/moneta-core/src/main/java/org/javamoney/moneta/spi/CompoundRateProvider.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * This class implements a {@link ExchangeRateProvider} that delegates calls to
@@ -47,6 +48,8 @@ public class CompoundRateProvider extends AbstractRateProvider {
      * The {@link ExchangeRateProvider} instances.
      */
     private final List<ExchangeRateProvider> providers = new ArrayList<>();
+
+    private static final Logger logger = Logger.getLogger(CompoundRateProvider.class.getName());
 
     /**
      * Constructor.
@@ -102,6 +105,10 @@ public class CompoundRateProvider extends AbstractRateProvider {
      */
     @Override
     public ExchangeRate getExchangeRate(ConversionQuery conversionQuery) {
+        return getExchangeRate(conversionQuery, false);
+    }
+
+    public ExchangeRate getExchangeRate(ConversionQuery conversionQuery, boolean failFast) {
         for (ExchangeRateProvider prov : this.providers) {
             try {
                 if (prov.isAvailable(conversionQuery)) {
@@ -111,15 +118,18 @@ public class CompoundRateProvider extends AbstractRateProvider {
                     }
                 }
             } catch (Exception e) {
-                throw new CurrencyConversionException(conversionQuery.getBaseCurrency(), conversionQuery.getCurrency(), null,
-                    "Rate Provider did not return data though at check before data was flagged as available," +
-                        " provider=" + prov.getContext().getProviderName() + ", query=" + conversionQuery, e);
+                if (failFast) {
+                    throw new CurrencyConversionException(conversionQuery.getBaseCurrency(), conversionQuery.getCurrency(), null,
+                            "Rate Provider did not return data though at check before data was flagged as available," +
+                                    " provider=" + prov.getContext().getProviderName() + ", query=" + conversionQuery, e);
+                } else {
+                    logger.warning("Rate Provider did not return data though at check before data was flagged as available," +
+                            " provider=" + prov.getContext().getProviderName() + ", query=" + conversionQuery + ", error=" + e.getMessage());
+                }
             }
         }
         throw new CurrencyConversionException(conversionQuery.getBaseCurrency(), conversionQuery.getCurrency(), null,
                 "All delegate providers failed to deliver rate, providers=" + this.providers +
                         ", query=" + conversionQuery);
     }
-
-
 }

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/CompoundRateProviderTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/CompoundRateProviderTest.java
@@ -1,0 +1,66 @@
+package org.javamoney.moneta.spi;
+
+import org.testng.annotations.Test;
+
+import javax.money.convert.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+import static org.testng.Assert.*;
+
+public class CompoundRateProviderTest {
+
+    @Test
+    public void testGetExchangeRate() {
+        String baseCurrency = "EUR";
+        String termCurrency = "GBP";
+        LocalDate date = lastWeekTuesday();
+        ConversionQuery conversionQuery = ConversionQueryBuilder.of()
+                .setBaseCurrency(baseCurrency)
+                .setTermCurrency(termCurrency)
+                .set(date)
+                .build();
+
+        ExchangeRateProvider compoundRateProvider = MonetaryConversions.getExchangeRateProvider("ECB", "ECB-HIST90");
+        assertNotNull(compoundRateProvider.getExchangeRate(conversionQuery));
+    }
+
+    @Test
+    public void testGetExchangeRateAllProvidersFail() {
+        String baseCurrency = "EUR";
+        String termCurrency = "GBP";
+        LocalDate date = lastWeekTuesday();
+        ConversionQuery conversionQuery = ConversionQueryBuilder.of()
+                .setBaseCurrency(baseCurrency)
+                .setTermCurrency(termCurrency)
+                .set(date)
+                .build();
+
+        ExchangeRateProvider compoundRateProvider = MonetaryConversions.getExchangeRateProvider("ECB", "IMF");
+        assertThrows(CurrencyConversionException.class, () -> compoundRateProvider.getExchangeRate(conversionQuery));
+    }
+
+    @Test
+    public void testGetExchangeRateFailingFast() {
+        String baseCurrency = "EUR";
+        String termCurrency = "GBP";
+        LocalDate date = lastWeekTuesday();
+        ConversionQuery conversionQuery = ConversionQueryBuilder.of()
+                .setBaseCurrency(baseCurrency)
+                .setTermCurrency(termCurrency)
+                .set(date)
+                .build();
+
+        // Need to cast to CompoundRateProvider to access the getExchangeRate method that takes a boolean parameter
+        CompoundRateProvider compoundRateProvider = (CompoundRateProvider) MonetaryConversions.getExchangeRateProvider("ECB", "ECB-HIST90");
+        assertThrows(CurrencyConversionException.class, () -> compoundRateProvider.getExchangeRate(conversionQuery, true));
+    }
+
+    private LocalDate lastWeekTuesday() {
+        LocalDate today = LocalDate.now();
+        LocalDate lastTuesday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.TUESDAY));
+        return lastTuesday.minusWeeks(1);
+    }
+}

--- a/moneta-core/src/test/java/org/javamoney/moneta/spi/CompoundRateProviderTest.java
+++ b/moneta-core/src/test/java/org/javamoney/moneta/spi/CompoundRateProviderTest.java
@@ -23,8 +23,9 @@ public class CompoundRateProviderTest {
                 .set(date)
                 .build();
 
-        ExchangeRateProvider compoundRateProvider = MonetaryConversions.getExchangeRateProvider("ECB", "ECB-HIST90");
-        assertNotNull(compoundRateProvider.getExchangeRate(conversionQuery));
+        // Need to cast to CompoundRateProvider to access the getExchangeRate method that takes a boolean parameter
+        CompoundRateProvider compoundRateProvider = (CompoundRateProvider) MonetaryConversions.getExchangeRateProvider("ECB", "ECB-HIST90");
+        assertNotNull(compoundRateProvider.getExchangeRate(conversionQuery, false));
     }
 
     @Test
@@ -38,8 +39,9 @@ public class CompoundRateProviderTest {
                 .set(date)
                 .build();
 
-        ExchangeRateProvider compoundRateProvider = MonetaryConversions.getExchangeRateProvider("ECB", "IMF");
-        assertThrows(CurrencyConversionException.class, () -> compoundRateProvider.getExchangeRate(conversionQuery));
+        // Need to cast to CompoundRateProvider to access the getExchangeRate method that takes a boolean parameter
+        CompoundRateProvider compoundRateProvider = (CompoundRateProvider) MonetaryConversions.getExchangeRateProvider("ECB", "IMF");
+        assertThrows(CurrencyConversionException.class, () -> compoundRateProvider.getExchangeRate(conversionQuery, false));
     }
 
     @Test
@@ -53,9 +55,8 @@ public class CompoundRateProviderTest {
                 .set(date)
                 .build();
 
-        // Need to cast to CompoundRateProvider to access the getExchangeRate method that takes a boolean parameter
-        CompoundRateProvider compoundRateProvider = (CompoundRateProvider) MonetaryConversions.getExchangeRateProvider("ECB", "ECB-HIST90");
-        assertThrows(CurrencyConversionException.class, () -> compoundRateProvider.getExchangeRate(conversionQuery, true));
+        ExchangeRateProvider compoundRateProvider = MonetaryConversions.getExchangeRateProvider("ECB", "ECB-HIST90");
+        assertThrows(CurrencyConversionException.class, () -> compoundRateProvider.getExchangeRate(conversionQuery));
     }
 
     private LocalDate lastWeekTuesday() {


### PR DESCRIPTION
This PR introduces a retry mechanism to `CompoundRateProvider.getExchangeRate` by adding an overloaded version with a `failFast` parameter:
- if `failFast` is set to `true`, the method retains its original behavior, throwing an exception immediately on the first provider failure.
- if `failFast` is set to `false`, the method logs a warning and continues attempting to retrieve an exchange rate from the next provider.

This way users can choose whether to fail immediately or attempt to use other providers if one fails. The default behavior remains unchanged (i.e., fails immediately), ensuring backward compatibility.

This change addresses issue [#385](https://github.com/JavaMoney/jsr354-ri/issues/385) and provides more flexibility in handling provider failures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/JavaMoney/jsr354-ri/419)
<!-- Reviewable:end -->
